### PR TITLE
Ad list view

### DIFF
--- a/src/AdGrid.vue
+++ b/src/AdGrid.vue
@@ -1,0 +1,81 @@
+<style lang="scss">
+.adGrid {
+  img, .nsfwAd, a div {
+    position: absolute;
+    display: block;
+    overflow: hidden;
+    font-size: 11px;
+    color: rgba(0, 0, 0, 0.7);
+    white-space: nowrap;
+  }
+
+  .nsfwAd {
+    background: #000;
+  }
+
+  &.active img {
+    box-shadow: 0px 0px 0px 1px rgba(255, 255, 255, 0.4) inset;
+  }
+
+  .previewAd {
+    background: rgba(255, 255, 255, 0.8);
+    border: 1px solid rgba(255, 255, 255, 0.9);
+    z-index: 5;
+  }
+  .previewAd.locked {
+    background: #ffcc47;
+  }
+}
+</style>
+
+<template>
+  <div :class="{ adGrid: true, active: !!$store.state.previewAd }" :style="gridStyle(prerendered)">
+    <template v-for="ad in $store.state.ads" v-if="ad">
+      <Ad :showNSFW="showNSFW" :ad="ad" :skipImage="!loadRemoteImages"></Ad>
+    </template>
+    <vue-draggable-resizable ref="draggable" :active="true" :minw="10" :minh="10" :x="$store.state.previewAd.x" :y="$store.state.previewAd.y" :w="80" :h="40" :grid="[10,10]" :parent="true" @dragstop="updatePreview" @resizestop="updatePreview" :draggable="!previewLocked" :resizable="!previewLocked" v-if="$store.state.previewAd" v-bind:class="{previewAd: true, locked: previewLocked}">
+      <Buy :web3="web3" :contract="contract" :isReadOnly="isReadOnly" @buy="onBuy"></Buy>
+    </vue-draggable-resizable>
+  </div>
+</template>
+
+<script>
+import Ad from './Ad.vue'
+import Buy from './Buy.vue'
+import VueDraggableResizable from 'vue-draggable-resizable'
+
+export default {
+  props: ["web3", "contract", "isReadOnly", "showNSFW", "prerendered"],
+  data() {
+    return {
+      previewLocked: false,
+      loadRemoteImages: this.prerendered ? this.prerendered.loadRemoteImages : true,
+    }
+  },
+  methods: {
+    onBuy: function (ad) {
+      this.previewLocked = true;
+    },
+    updatePreview(x, y, width, height) {
+      const dragged = this.$refs.draggable;
+      this.$store.commit('updatePreview', {
+        'x': dragged.left,
+        'y': dragged.top,
+        'width': dragged.width,
+        'height': dragged.height,
+      });
+    },
+    gridStyle(config) {
+      if (!config) return;
+      return {
+        'background-image': 'url(' + config.image + ')',
+      }
+    },
+  },
+  components: {
+    'vue-draggable-resizable': VueDraggableResizable,
+    Ad,
+    Buy,
+  },
+}
+</script>

--- a/src/AdList.vue
+++ b/src/AdList.vue
@@ -7,6 +7,12 @@
     padding: 5px;
   }
 
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
   li {
     background: #ddd;
     margin-bottom: 0.5em;
@@ -16,12 +22,14 @@
 
 <template>
   <div class="adList">
-    <ul v-for="ad in $store.state.ads" v-if="ad && ad.image">
+    <p>Listing {{ num }} published ads and omitting {{ omitted }} empty ads.</p>
+    <p><strong>Newest ad first:</strong></p>
+
+    <ul v-for="ad in listAds" v-if="ad && ad.image">
       <li>
         <Ad :showNSFW="showNSFW" :ad="ad"></Ad>
       </li>
     </ul>
-    <p>Empty ads are omitted in list view.</p>
   </div>
 </template>
 
@@ -30,6 +38,29 @@ import Ad from './Ad.vue'
 
 export default {
   props: ["showNSFW"],
+  data() {
+    return {
+      omitted: 0,
+      num: 0,
+    }
+  },
+  computed: {
+    listAds() {
+      let omitted = 0, num = 0;
+      const ads = [];
+      for (let ad of this.$store.state.ads) {
+        if (!ad || !ad.image) {
+          omitted += 1;
+        }
+        num += 1;
+        ads.push(ad);
+      }
+      ads.reverse();
+      this.omitted = omitted;
+      this.num = num;
+      return ads;
+    },
+  },
   components: {
     Ad,
   },

--- a/src/AdList.vue
+++ b/src/AdList.vue
@@ -1,0 +1,37 @@
+<style lang="scss">
+.adList {
+  background: #fff;
+
+  img {
+    vertical-align: middle;
+    padding: 5px;
+  }
+
+  li {
+    background: #ddd;
+    margin-bottom: 0.5em;
+  }
+}
+</style>
+
+<template>
+  <div class="adList">
+    <ul v-for="ad in $store.state.ads" v-if="ad && ad.image">
+      <li>
+        <Ad :showNSFW="showNSFW" :ad="ad"></Ad>
+      </li>
+    </ul>
+    <p>Empty ads are omitted in list view.</p>
+  </div>
+</template>
+
+<script>
+import Ad from './Ad.vue'
+
+export default {
+  props: ["showNSFW"],
+  components: {
+    Ad,
+  },
+}
+</script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -57,6 +57,10 @@
             Contract on Etherscan
           </a>
         </li>
+        <li>
+          <a v-if="$store.state.gridVis" v-on:click="$store.commit('setVis', 'list')">List View</a>
+          <a v-else v-on:click="$store.commit('setVis', 'grid')">Grid View</a>
+        </li>
         <li v-if="$store.state.numNSFW > 0">
           <a v-if="!showNSFW" v-on:click="showNSFW = true">Show NSFW ({{$store.state.numNSFW}})</a>
           <a v-else v-on:click="showNSFW = false">Hide NSFW</a>

--- a/src/Homepage.vue
+++ b/src/Homepage.vue
@@ -1,32 +1,4 @@
 <style lang="scss">
-.adGrid {
-  img, .nsfwAd, a div {
-    position: absolute;
-    display: block;
-    overflow: hidden;
-    font-size: 11px;
-    color: rgba(0, 0, 0, 0.7);
-    white-space: nowrap;
-  }
-
-  .nsfwAd {
-    background: #000;
-  }
-
-  &.active img {
-    box-shadow: 0px 0px 0px 1px rgba(255, 255, 255, 0.4) inset;
-  }
-
-  .previewAd {
-    background: rgba(255, 255, 255, 0.8);
-    border: 1px solid rgba(255, 255, 255, 0.9);
-    z-index: 5;
-  }
-  .previewAd.locked {
-    background: #ffcc47;
-  }
-}
-
 .edit {
   display: inline-block;
   margin-top: 1em;
@@ -45,14 +17,7 @@
 
 <template>
   <div class="container">
-    <div :class="{ adGrid: true, active: !!$store.state.previewAd }" :style="gridStyle(prerendered)">
-      <template v-for="ad in $store.state.ads" v-if="ad">
-        <Ad :showNSFW="showNSFW" :ad="ad" :skipImage="!loadRemoteImages"></Ad>
-      </template>
-      <vue-draggable-resizable ref="draggable" :active="true" :minw="10" :minh="10" :x="$store.state.previewAd.x" :y="$store.state.previewAd.y" :w="80" :h="40" :grid="[10,10]" :parent="true" @dragstop="updatePreview" @resizestop="updatePreview" :draggable="!previewLocked" :resizable="!previewLocked" v-if="$store.state.previewAd" v-bind:class="{previewAd: true, locked: previewLocked}">
-        <Buy :web3="web3" :contract="contract" :isReadOnly="isReadOnly" @buy="onBuy"></Buy>
-      </vue-draggable-resizable>
-    </div>
+    <AdGrid :web3="web3" :contract="contract" :showNSFW="showNSFW" :isReadOnly="isReadOnly" :prerendered="prerendered"></AdGrid>
 
     <div class="edit" v-if="$store.state.numOwned > 0">
       {{$store.state.numOwned}} ads owned by you. <button v-on:click="showPublish = true" v-if="!showPublish">Edit Ads</button>
@@ -64,11 +29,9 @@
 </template>
 
 <script>
-import Ad from './Ad.vue'
-import Buy from './Buy.vue'
+import AdGrid from './AdGrid.vue'
 import Publish from './Publish.vue'
 import Offline from './Offline.vue'
-import VueDraggableResizable from 'vue-draggable-resizable'
 
 function toAd(i, r) {
   return {
@@ -90,27 +53,10 @@ export default {
   props: ["web3", "contract", "isReadOnly", "showNSFW", "prerendered"],
   data() {
     return {
-      previewLocked: false,
       showPublish: false,
-      loadRemoteImages: this.prerendered ? this.prerendered.loadRemoteImages : true,
     }
   },
   methods: {
-    onBuy: function (ad) {
-      this.previewLocked = true;
-    },
-    updatePreview(x, y, width, height) {
-      const dragged = this.$refs.draggable;
-      this.$store.commit('updatePreview', {
-        'x': dragged.left,
-        'y': dragged.top,
-        'width': dragged.width,
-        'height': dragged.height,
-      });
-    },
-    isOwner(account) {
-      this.$store.state.accounts[account] || false;
-    },
     loadAds() {
       this.$store.commit('clearAds');
       this.contract.getAdsLength.call(function(err, res) {
@@ -143,12 +89,6 @@ export default {
         }
       }.bind(this);
       xhr.send();
-    },
-    gridStyle(config) {
-      if (!config) return;
-      return {
-        'background-image': 'url(' + config.image + ')',
-      }
     },
   },
   created() {
@@ -194,11 +134,9 @@ export default {
     }.bind(this))
   },
   components: {
-    'vue-draggable-resizable': VueDraggableResizable,
-    Ad,
-    Buy,
     Publish,
     Offline,
+    AdGrid,
   },
 }
 </script>

--- a/src/Homepage.vue
+++ b/src/Homepage.vue
@@ -17,7 +17,8 @@
 
 <template>
   <div class="container">
-    <AdGrid :web3="web3" :contract="contract" :showNSFW="showNSFW" :isReadOnly="isReadOnly" :prerendered="prerendered"></AdGrid>
+    <AdGrid v-if="$store.state.gridVis" :web3="web3" :contract="contract" :showNSFW="showNSFW" :isReadOnly="isReadOnly" :prerendered="prerendered"></AdGrid>
+    <AdList v-else :showNSFW="showNSFW"></AdList>
 
     <div class="edit" v-if="$store.state.numOwned > 0">
       {{$store.state.numOwned}} ads owned by you. <button v-on:click="showPublish = true" v-if="!showPublish">Edit Ads</button>
@@ -30,6 +31,7 @@
 
 <script>
 import AdGrid from './AdGrid.vue'
+import AdList from './AdList.vue'
 import Publish from './Publish.vue'
 import Offline from './Offline.vue'
 
@@ -137,6 +139,7 @@ export default {
     Publish,
     Offline,
     AdGrid,
+    AdList,
   },
 }
 </script>

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -73,6 +73,7 @@ export default new Vuex.Store({
     pixelsOwned: 0,
     grid: null, // lazy load
     previewAd: null,
+    gridVis: true,
   },
   mutations: {
     setAccount(state, account) {
@@ -88,6 +89,7 @@ export default new Vuex.Store({
       }
     },
     updatePreview(state, ad) {
+      state.gridVis = true; // Buy button forces grid view
       state.previewAd = Object.assign(state.previewAd || {}, ad);
     },
     clearPreview(state) {
@@ -100,6 +102,10 @@ export default new Vuex.Store({
       state.ownedAds = {};
       state.numOwned = 0;
       state.pixelsOwned = 0;
+    },
+    setVis(state, vis) {
+      // Valid values: 'grid' and 'list', default to 'grid'
+      state.gridVis = vis !== 'list';
     },
     setAdsLength(state, len) {
       state.ads.length = len;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -96,6 +96,7 @@ export default new Vuex.Store({
       state.previewAd = null;
     },
     clearAds(state) {
+      state.grid = null;
       state.ads = [];
       state.adsPixels = 0;
       state.numNSFW = 0;


### PR DESCRIPTION
- Refactors the AdGrid into its own component
- Adds a new AdList component
- "List View" button in the footer
- List view omits empty ads

I was considering just rendering plaintext links rather than the full ads but we have a bunch of logic in the Ad component that determines the validity of an ad (e.g. blacklisting) which I didn't want to mess with right now.

@mveytsman What do you think?

![image](https://user-images.githubusercontent.com/6292/32991257-0e06474c-cd06-11e7-9dc2-081a0d814a1b.png)
