### PR TITLE
Fix local testing without google analytics

### DIFF
--- a/src/Buy.vue
+++ b/src/Buy.vue
@@ -48,11 +48,13 @@ const ethPerPixel = 1000 / 1000000;
 export default {
   props: ["web3", "contract", "isReadOnly"],
   data() {
-    ga('send', {
-      hitType: 'event',
-      eventCategory: this.contract._network,
-      eventAction: 'buy-open',
-    });
+    if (typeof ga === "function") {
+      ga('send', {
+        hitType: 'event',
+        eventCategory: this.contract._network,
+        eventAction: 'buy-open',
+      });
+    }
 
     return {
       error: null,
@@ -95,22 +97,26 @@ export default {
       const weiPrice = this.web3.toWei(this.price(ad.width, ad.height), "ether");
       const x = Math.floor(ad.x/10), y = Math.floor(ad.y/10), width = Math.floor(ad.width/10), height = Math.floor(ad.height/10);
       const account = this.$store.state.activeAccount;
-      ga('send', {
-        hitType: 'event',
-        eventCategory: this.contract._network,
-        eventAction: 'buy-submit',
-        eventValue: weiPrice,
-        eventLabel: ad.width + "x" + ad.height,
-      });
+      if (typeof ga === "function") {
+        ga('send', {
+          hitType: 'event',
+          eventCategory: this.contract._network,
+          eventAction: 'buy-submit',
+          eventValue: weiPrice,
+          eventLabel: ad.width + "x" + ad.height,
+        });
+      }
 
       this.contract.buy.sendTransaction(x, y, width, height, { value: weiPrice, from: account }, function(err, res) {
         if (err) {
-          ga('send', {
-            hitType: 'event',
-            eventCategory: this.contract._network,
-            eventAction: 'buy-error',
-            eventLabel: JSON.stringify(err),
-          });
+          if (typeof ga === "function") {
+            ga('send', {
+              hitType: 'event',
+              eventCategory: this.contract._network,
+              eventAction: 'buy-error',
+              eventLabel: JSON.stringify(err),
+            });
+          }
 
           if (err.message && err.message.indexOf('User denied transaction signature.') !== -1)  {
             // Aborted, revert to original state.

--- a/src/Publish.vue
+++ b/src/Publish.vue
@@ -126,29 +126,35 @@ export default {
   },
   methods: {
     publish() {
-      ga('send', {
-        hitType: 'event',
-        eventCategory: this.contract._network,
-        eventAction: 'publish-submit',
-      });
-      this.contract.publish.sendTransaction(this.ad.idx, this.ad.link, this.ad.image, this.ad.title, Number(this.ad.NSFW), { from: this.ad.owner }, function(err, res) {
+      if (typeof ga === "function") {
         ga('send', {
           hitType: 'event',
           eventCategory: this.contract._network,
-          eventAction: 'publish-error',
-          eventLabel: JSON.stringify(err),
+          eventAction: 'publish-submit',
         });
+      }
+      this.contract.publish.sendTransaction(this.ad.idx, this.ad.link, this.ad.image, this.ad.title, Number(this.ad.NSFW), { from: this.ad.owner }, function(err, res) {
+        if (typeof ga === "function") {
+          ga('send', {
+            hitType: 'event',
+            eventCategory: this.contract._network,
+            eventAction: 'publish-error',
+            eventLabel: JSON.stringify(err),
+          });
+        }
 
         this.ad = false;
         if (err) {
           this.error = err;
           return;
         }
-        ga('send', {
-          hitType: 'event',
-          eventCategory: this.contract._network,
-          eventAction: 'publish-success',
-        });
+        if (typeof ga === "function") {
+          ga('send', {
+            hitType: 'event',
+            eventCategory: this.contract._network,
+            eventAction: 'publish-success',
+          });
+        }
       }.bind(this));
       return false;
     },


### PR DESCRIPTION
When used locally, the "ga" variable for google analytics is null, however some
handlers require it.  This makes it so "ga" being null is ignored.