### PR TITLE
Call `ethereum.enable()` on page load if we detect web3

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -113,10 +113,13 @@ function waitForWeb3(options, cb) {
   const web3Fallback = options.web3Fallback || "http://localhost:8545/";
 
   function getWeb3() {
-    let web3 = window.web3;
+    let web3 = window.ethereum;
     if (typeof web3 !== 'undefined') {
-      web3 = new Web3(web3.currentProvider);
+      // we're using metamask
+      window.ethereum.enable()
+      web3 = new Web3(window.ethereum)
     } else {
+      // we're using a fallback
       web3 = new Web3(new Web3.providers.HttpProvider(web3Fallback));
     }
     try {

--- a/src/App.vue
+++ b/src/App.vue
@@ -115,7 +115,7 @@ function waitForWeb3(options, cb) {
   function getWeb3() {
     let web3 = window.ethereum;
     if (typeof web3 !== 'undefined') {
-      // we're using metamask
+      // we're using a wallet browser
       window.ethereum.enable()
       web3 = new Web3(window.ethereum)
     } else {


### PR DESCRIPTION
This is a quick fix for #26, we call `ethereum.enable()` when the page is loaded.

Ideally we'd call it on the click on buy, but this seemed faster to implement as a fix before we improve the UX.