### PR TITLE
KetherNFT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,6 @@ contracts: build/contracts/*
 build/contracts/%.json: contracts/%.sol
 	npx hardhat compile
 
-node_modules/: package.json
+node_modules/: package.json package-lock.json
 	npm install
 	touch node_modules/

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ deploy-dapp: build ../thousandetherhomepage.github.io
 	echo "Push it."
 
 deploy-contract:
-	# TODO: $(TRUFFLEBIN) migrate -f 2 --network rinkeby --reset
+	npx hardhat run scripts/deployKetherNFT.js --network rinkeby
 
 withdraw:
 	npx hardhat run scripts/withdraw.js --network mainnet

--- a/contracts/IKetherHomepage.sol
+++ b/contracts/IKetherHomepage.sol
@@ -28,19 +28,6 @@ interface IKetherHomepage {
         address to
     );
 
-    struct Ad {
-        address owner;
-        uint x;
-        uint y;
-        uint width;
-        uint height;
-        string link;
-        string image;
-        string title;
-        bool NSFW;
-        bool forceNSFW;
-    }
-
     /// ads are stored in an array, the id of an ad is its index in this array.
     function ads(uint _idx) external view returns (address,uint,uint,uint,uint,string memory,string memory,string memory,bool,bool);
 

--- a/contracts/IKetherHomepage.sol
+++ b/contracts/IKetherHomepage.sol
@@ -28,6 +28,21 @@ interface IKetherHomepage {
         address to
     );
 
+    struct Ad {
+        address owner;
+        uint x;
+        uint y;
+        uint width;
+        uint height;
+        string link;
+        string image;
+        string title;
+        bool NSFW;
+        bool forceNSFW;
+    }
+
+    /// ads are stored in an array, the id of an ad is its index in this array.
+    function ads(uint _idx) external view returns (Ad memory);
 
     function buy(uint _x, uint _y, uint _width, uint _height) external payable returns (uint idx);
 

--- a/contracts/IKetherHomepage.sol
+++ b/contracts/IKetherHomepage.sol
@@ -1,0 +1,41 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IKetherHomepage {
+    /// Buy is emitted when an ad unit is reserved.
+    event Buy(
+        uint indexed idx,
+        address owner,
+        uint x,
+        uint y,
+        uint width,
+        uint height
+    );
+
+    /// Publish is emitted whenever the contents of an ad is changed.
+    event Publish(
+        uint indexed idx,
+        string link,
+        string image,
+        string title,
+        bool NSFW
+    );
+
+    /// SetAdOwner is emitted whenever the ownership of an ad is transfered
+    event SetAdOwner(
+        uint indexed idx,
+        address from,
+        address to
+    );
+
+
+    function buy(uint _x, uint _y, uint _width, uint _height) external payable returns (uint idx);
+
+    function publish(uint _idx, string calldata _link, string calldata _image, string calldata _title, bool _NSFW) external;
+
+    function setAdOwner(uint _idx, address _newOwner) external;
+
+    function forceNSFW(uint _idx, bool _NSFW) external;
+
+    function withdraw() external;
+}

--- a/contracts/IKetherHomepage.sol
+++ b/contracts/IKetherHomepage.sol
@@ -42,7 +42,7 @@ interface IKetherHomepage {
     }
 
     /// ads are stored in an array, the id of an ad is its index in this array.
-    function ads(uint _idx) external view returns (Ad memory);
+    function ads(uint _idx) external view returns (address,uint,uint,uint,uint,string memory,string memory,string memory,bool,bool);
 
     function buy(uint _x, uint _y, uint _width, uint _height) external payable returns (uint idx);
 

--- a/contracts/IKetherHomepage.sol
+++ b/contracts/IKetherHomepage.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity >=0.8.4;
 
 interface IKetherHomepage {
     /// Buy is emitted when an ad unit is reserved.

--- a/contracts/KetherHomepageV2.sol
+++ b/contracts/KetherHomepageV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8;
+pragma solidity >=0.8.4;
 
 import "hardhat/console.sol";
 

--- a/contracts/KetherHomepageV2.sol
+++ b/contracts/KetherHomepageV2.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8;
+
+import "hardhat/console.sol";
+
+import "./IKetherHomepage.sol";
+
+/// KetherHomepage is same as the old one, but ported to solidity v0.8
+contract KetherHomepageV2 is IKetherHomepage {
+    /// Price is 1 kether divided by 1,000,000 pixels
+    uint public constant weiPixelPrice = 1000000000000000;
+
+    /// Each grid cell represents 100 pixels (10x10).
+    uint public constant pixelsPerCell = 100;
+
+    bool[100][100] public grid;
+
+    // contractOwner can withdraw the funds and override NSFW status of ad units.
+    address contractOwner;
+
+    // withdrawWallet is the fixed destination of funds to withdraw. It is
+    // separate from contractOwner to allow for a cold storage destination.
+    address payable withdrawWallet;
+
+    struct Ad {
+        address owner;
+        uint x;
+        uint y;
+        uint width;
+        uint height;
+        string link;
+        string image;
+        string title;
+        bool NSFW;
+        bool forceNSFW;
+    }
+
+    /// ads are stored in an array, the id of an ad is its index in this array.
+    Ad[] public override ads;
+
+    constructor(address _contractOwner, address payable _withdrawWallet) {
+        require(_contractOwner != address(0));
+        require(_withdrawWallet != address(0));
+
+        contractOwner = _contractOwner;
+        withdrawWallet = _withdrawWallet;
+    }
+
+    /// getAdsLength tells you how many ads there are
+    function getAdsLength() view public returns (uint) {
+        return ads.length;
+    }
+
+    /// Ads must be purchased in 10x10 pixel blocks.
+    /// Each coordinate represents 10 pixels. That is,
+    ///   _x=5, _y=10, _width=3, _height=3
+    /// Represents a 30x30 pixel ad at coordinates (50, 100)
+    function buy(uint _x, uint _y, uint _width, uint _height) payable public override returns (uint idx) {
+        uint cost = _width * _height * pixelsPerCell * weiPixelPrice;
+        require(cost > 0);
+        require(msg.value >= cost);
+
+        // Loop over relevant grid entries
+        for(uint i=0; i<_width; i++) {
+            for(uint j=0; j<_height; j++) {
+                if (grid[_x+i][_y+j]) {
+                    // Already taken, undo.
+                    revert();
+                }
+                grid[_x+i][_y+j] = true;
+            }
+        }
+
+        // We reserved space in the grid, now make a placeholder entry.
+        Ad memory ad = Ad(msg.sender, _x, _y, _width, _height, "", "", "", false, false);
+        ads.push(ad);
+        idx = ads.length - 1;
+        emit Buy(idx, msg.sender, _x, _y, _width, _height);
+        return idx;
+    }
+
+    /// Publish allows for setting the link, image, and NSFW status for the ad
+    /// unit that is identified by the idx which was returned during the buy step.
+    /// The link and image must be full web3-recognizeable URLs, such as:
+    ///  - bzz://a5c10851ef054c268a2438f10a21f6efe3dc3dcdcc2ea0e6a1a7a38bf8c91e23
+    ///  - bzz://mydomain.eth/ad.png
+    ///  - https://cdn.mydomain.com/ad.png
+    /// Images should be valid PNG.
+    function publish(uint _idx, string memory _link, string memory _image, string memory _title, bool _NSFW) public override {
+        Ad storage ad = ads[_idx];
+        require(msg.sender == ad.owner);
+        ad.link = _link;
+        ad.image = _image;
+        ad.title = _title;
+        ad.NSFW = _NSFW;
+
+        emit Publish(_idx, ad.link, ad.image, ad.title, ad.NSFW || ad.forceNSFW);
+    }
+
+    /// setAdOwner changes the owner of an ad unit
+    function setAdOwner(uint _idx, address _newOwner) public override {
+        Ad storage ad = ads[_idx];
+        require(msg.sender == ad.owner, "KetherHomepage: sender is not owner");
+        ad.owner = _newOwner;
+
+        emit SetAdOwner(_idx, msg.sender, _newOwner);
+    }
+
+    /// forceNSFW allows the owner to override the NSFW status for a specific ad unit.
+    function forceNSFW(uint _idx, bool _NSFW) public override {
+        require(msg.sender == contractOwner);
+        Ad storage ad = ads[_idx];
+        ad.forceNSFW = _NSFW;
+
+        emit Publish(_idx, ad.link, ad.image, ad.title, ad.NSFW || ad.forceNSFW);
+    }
+
+    /// withdraw allows the owner to transfer out the balance of the contract.
+    function withdraw() public override {
+        require(msg.sender == contractOwner);
+        withdrawWallet.transfer(address(this).balance);
+    }
+}

--- a/contracts/KetherHomepageV2.sol
+++ b/contracts/KetherHomepageV2.sol
@@ -65,7 +65,7 @@ contract KetherHomepageV2 is IKetherHomepage {
             for(uint j=0; j<_height; j++) {
                 if (grid[_x+i][_y+j]) {
                     // Already taken, undo.
-                    revert();
+                    revert("KetherHomepage: buy ad slot already taken");
                 }
                 grid[_x+i][_y+j] = true;
             }

--- a/contracts/KetherNFT.sol
+++ b/contracts/KetherNFT.sol
@@ -88,8 +88,9 @@ contract KetherNFT is ERC721 {
   function unwrap(uint _idx, address _newOwner) external {
     require(ownerOf(_idx) == _msgSender(), "KetherNFT: unwrap for sender that is not owner");
 
-
     instance.setAdOwner(_idx, _newOwner);
+    require(_getAdOwner(_idx) == _newOwner, "KetherNFT: unwrap ownership transfer failed");
+
     _burn(_idx);
   }
 
@@ -140,4 +141,21 @@ contract KetherNFT is ERC721 {
     instance.publish(_idx, _link, _image, _title, _NSFW);
   }
 
+
+  /// adminRecoverTrapped allows us to transfer ownership of ads that were
+  /// incorrectly transferred to this contract without an NFT being minted.
+  /// This should never happen, but we include this recovery function in case
+  /// there is a bug in the DApp that somehow falls into this condition.
+  /// Note that this function does *not* give admin any control over properly
+  /// minted ads/NFTs.
+  function adminRecoverTrapped(uint _idx, address _to) external {
+    require(_msgSender() == admin, "KetherNFT: recovery must be done by admin");
+    require(!_exists(_idx), "KetherNFT: recovery can only be done on unminted ads");
+    require(_getAdOwner(_idx) == address(this), "KetherNFT: ad not held by contract");
+
+    instance.setAdOwner(_idx, _to);
+  }
+
+  // TODO: adminTransfer
+  // TODO: adminDisableRenderUpgrade
 }

--- a/contracts/KetherNFT.sol
+++ b/contracts/KetherNFT.sol
@@ -15,7 +15,7 @@ import "hardhat/console.sol";
 contract Wrapper {
   constructor(address target, bytes memory payload) {
     (bool success,) = target.call(payload);
-    require(success);
+    require(success, "Wrapper: target call failed");
     selfdestruct(payable(target));
   }
 }
@@ -53,7 +53,8 @@ contract KetherNFT is ERC721 {
   }
 
   function _getAdOwner(uint _idx) internal view returns (address) {
-      return instance.ads(_idx).owner;
+      (address owner,,,,,,,,,) = instance.ads(_idx);
+      return owner;
   }
 
   /// wrap mints an NFT if the ad unit's ownership has been transferred to the

--- a/contracts/KetherNFT.sol
+++ b/contracts/KetherNFT.sol
@@ -11,47 +11,13 @@ import "./IKetherHomepage.sol";
 import "hardhat/console.sol";
 
 
-// 1. Precompute deterministic contract address 0xSWAP
-// 2. Call on-chain KetherHomepage.setAdOwner(_idx, 0xSWAP)
-// 3. Call on-chain deploy TransientOwnerSwapper(address(KetherNFT), _idx) to address 0xSWAP
-//    -> Inside, it calls KetherNFT.wrap(_idx)?
-
-contract TransientOwnerSwapper {
-  uint idx;
-  address to;
-  IKetherHomepage kether;
-
-  constructor(IKetherHomepage _kether, KetherNFT _target, uint _idx) {
-    idx = _idx;
-    to = address(_target);
-    kether = _kether;
-
-    _target.wrap(_idx, msg.sender);
-
+// TODO: Name this something really cool
+contract Wrapper {
+  constructor(address target, bytes calldata payload) {
+    (bool success,) = target.call(payload);
+    require(success);
     selfdestruct();
   }
-
-  function transfer() external {
-    _kether.setAdOwner(idx, to);
-  }
-}
-
-contract Wrapper {
-  address authorized;
-
-  constructor(address _authorized) {
-    authorized = _authorized;
-  }
-
-  function call(address target, bytes memory payload) (bool, bytes memory) {
-    require(msg.sender == authorized, "Wrapper: call must be done by authorized sender");
-
-    return target.call(payload);
-  }
-}
-
-interface Transferer {
-  function transfer(address _from, address _to, uint _tokenId) external;
 }
 
 contract KetherNFT is ERC721 {
@@ -68,16 +34,20 @@ contract KetherNFT is ERC721 {
     metadataSigner = _metadataSigner;
   }
 
-  function precompute(address _owner) pure public (bytes32 salt, address wrapper) {
+  function _wrapPayload(uint _idx, address _owner) internal pure bytes32 {
+    return abi.encodeWithSignature("setAdOwner(uint256,address)", _idx, address(this));
+  }
+
+  function precompute(uint _idx, address _owner) pure public (bytes32 salt, address wrapper) {
     bytes32 salt = bytes32(_owner);
 
     address predictedAddress = address(uint160(uint(keccak256(abi.encodePacked(
       bytes1(0xff),
       address(this),
       salt,
-      keccak256(abi.encodePacked(
-        type(D).creationCode,
-        arg
+      keccak256(abi.encodePacked( // FIXME: Should this be encodeWithSignature?
+        type(Wrapper).creationCode,
+        address(instance), _wrapPayload(_idx, _owner),
       ))
     )))));
     return salt, predictedAddress;
@@ -89,14 +59,8 @@ contract KetherNFT is ERC721 {
 
     require(instance.ads[_idx].owner == precomputedWrapper, "KetherNFT: owner needs to be our wrapper");
 
-    // TODO: Check if wrapper already exists on precomputed address, use that instead.
-    Wrapper w = new Wrapper{salt: salt}(address(this));
-    require(address(w) == precomputedWrapper, "KetherNFT: precomputedWrapper is incorrect");
-
-    (bool success,) = w.call(
-      address(instance),
-      abi.encodeWithSignature("setAdOwner(uint256,address)", _idx, address(this)));
-    require(success, "KetherNFT: setAdOwner call failed");
+    // Wrapper self-destructs on construction
+    new Wrapper{salt: salt}(_wrapPayload(_idx, _owner));
 
     require(instance.ads[_idx].owner == address(this), "KetherNFT: owner needs to be KetherNFT");
     _mint(_owner, _idx);
@@ -105,11 +69,7 @@ contract KetherNFT is ERC721 {
   function unwrap(uint _idx, address _newOwner) external {
     require(ownerOf(_idx) == msg.sender, "KetherNFT: unwrap for sender that is not owner");
 
-    (bool success,) = w.call(
-      address(instance),
-      abi.encodeWithSignature("setAdOwner(uint256,address)", _idx, msg.sender));
-    require(success, "KetherNFT: setAdOwner call failed");
-
+    instance.setAdOwner(_idx, _newOwner);
     _burn(_idx);
   }
 
@@ -136,12 +96,7 @@ contract KetherNFT is ERC721 {
   function publish(uint _idx, string calldata _link, string calldata _image, string calldata _title, bool _NSFW) external {
     require(getApproved(_idx) == msg.sender, "KetherNFT: publish for sender that is not approved");
 
-    // TODO: Finish this lol
-    (bool success,) = w.call(
-      address(instance),
-      abi.encodeWithSignature("publish(uint256,string,string,string,bool)", _idx, _link, _image, _title, _NSFW));
-
-    require(success, "KetherNFT: publish call failed");
+    instance.publish(_idx, _link, _image, _title, _NSFW);
   }
 
 }

--- a/contracts/KetherNFT.sol
+++ b/contracts/KetherNFT.sol
@@ -1,0 +1,67 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.7;
+
+// FIXME: Use 4.x pre-release which slims down the 721 implementation
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+import "KetherHomepage.sol";
+
+contract KetherNFT is ERC721 {
+  /// instance is the KetherHomepage contract that this wrapper interfaces with.
+  KetherHomepage public instance;
+
+  address public constant metadataSigner = 0x0; // TODO: ...
+
+  // TODO: Do we want to emit events?
+
+  constructor(address _ketherContract) ERC721("Thousand Ether Homepage Ad", "1KAD") {
+    instance = KetherHomepage(_ketherContract);
+  }
+
+  function wrap(uint _idx) external {
+    // FIXME: Should this be _safeMint? It's more gas but guarantees receiver supports ERC721
+    _mint(msg.sender, _idx);
+
+    // Transfer contract ownership to this contract as a delegate.
+    // -> KetherHomepage(_ketherContract).setAdOwner(_idx, newOwner);
+    (bool success, bytes memory returnData) = address(instance).delegatecall(
+      bytes4(keccak256("setAdOwner(uint, address)")), _idx, address(this));
+    require(success);
+  }
+
+  function unwrap(uint _idx, address _newOwner) external {
+    require(ownerOf(_idx) == msg.sender);
+
+    // TODO: Test that if this fails, the rest of the call fails
+    instance.setAdOwner(_idx, _newOwner);
+
+    _burn(_idx);
+  }
+
+  // TODO: Should we have a setTokenURI function so owners can change the rendering of their token?
+
+  function tokenURI(uint256 _tokenId) external pure view override(ERC721) returns (string memory) {
+    // FIXME: Replace with IPFS URI? Perhaps set on wrap?
+    return "ipfs://1000ether.com/ad/" + _tokenID; // FIXME: Need to convert the uint256 to string, maybe Strings.uint2str?
+  }
+
+  /// publish is a delegated proxy for KetherHomapage's publish function.
+  ///
+  /// Publish allows for setting the link, image, and NSFW status for the ad
+  /// unit that is identified by the idx which was returned during the buy step.
+  /// The link and image must be full web3-recognizeable URLs, such as:
+  ///  - bzz://a5c10851ef054c268a2438f10a21f6efe3dc3dcdcc2ea0e6a1a7a38bf8c91e23
+  ///  - bzz://mydomain.eth/ad.png
+  ///  - https://cdn.mydomain.com/ad.png
+  ///  - https://ipfs.io/ipfs/Qme7ss3ARVgxv6rXqVPiikMJ8u2NLgmgszg13pYrDKEoiu
+  ///  - ipfs://Qme7ss3ARVgxv6rXqVPiikMJ8u2NLgmgszg13pYrDKEoiu
+  /// Images should be valid PNG.
+  /// Content-addressable storage links like IPFS are encouraged.
+  function publish(uint _idx, string _link, string _image, string _title, bool _NSFW) external {
+    // FIXME: Should this be ownerOf? Letting approved accounts publish would allow lending.
+    require(getApproved(_idx) == msg.sender);
+
+    instance.publish(_idx, _link, _image, _title, _NSFW);
+  }
+
+}

--- a/contracts/KetherNFT.sol
+++ b/contracts/KetherNFT.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8;
 
 // FIXME: Use 4.x pre-release which slims down the 721 implementation
-import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 
 import "./IKetherHomepage.sol";
 
@@ -17,7 +17,7 @@ contract Wrapper {
   }
 }
 
-contract KetherNFT is ERC721 {
+contract KetherNFT is ERC721URIStorage {
   /// instance is the KetherHomepage contract that this wrapper interfaces with.
   IKetherHomepage public instance;
 
@@ -86,12 +86,14 @@ contract KetherNFT is ERC721 {
     _burn(_idx);
   }
 
-  // TODO: Should we have a setTokenURI function so owners can change the rendering of their token?
-  // TODO: If we let people set their own tokenURI, do we need another NSFW flag option here?
+  // FIXME: If we let people set their own tokenURI, do we need another NSFW flag option here?
 
-  function tokenURI(uint256 _tokenId) public view virtual override(ERC721) returns (string memory) {
-    // FIXME: Replace with IPFS URI? Perhaps set on wrap?
-    return "ipfs://1000ether.com/ad/TODO"; // FIXME: Need to convert the uint256 to string, maybe Strings.uint2str?
+  /// setTokenURI lets owners set their own token metadata URI to reflect their
+  /// published ad unit.
+  function setTokenURI(uint256 _idx, string memory _tokenURI) external {
+    require(_isApprovedOrOwner(msg.sender, _idx), "KetherNFT: setTokenURI for sender that is not approved");
+
+    _setTokenURI(_idx, _tokenURI);
   }
 
   /// publish is a delegated proxy for KetherHomapage's publish function.

--- a/contracts/KetherNFT.sol
+++ b/contracts/KetherNFT.sol
@@ -69,7 +69,7 @@ contract KetherNFT is ERC721 {
   function wrap(uint _idx, address _owner) external {
     (bytes32 salt, address precomputedWrapper) = precompute(_idx, _owner);
 
-    require(_getAdOwner(_idx) == precomputedWrapper, "KetherNFT: owner needs to be our wrapper before wrap");
+    require(_getAdOwner(_idx) == precomputedWrapper, "KetherNFT: owner needs to be the correct precommitted address");
 
     // Wrapper completes the transfer escrow atomically and self-destructs.
     new Wrapper{salt: salt}(address(instance), _wrapPayload(_idx));
@@ -107,7 +107,7 @@ contract KetherNFT is ERC721 {
   /// Images should be valid PNG.
   /// Content-addressable storage links like IPFS are encouraged.
   function publish(uint _idx, string calldata _link, string calldata _image, string calldata _title, bool _NSFW) external {
-    require(getApproved(_idx) == msg.sender, "KetherNFT: publish for sender that is not approved");
+    require(_isApprovedOrOwner(msg.sender, _idx), "KetherNFT: publish for sender that is not approved");
 
     instance.publish(_idx, _link, _image, _title, _NSFW);
   }

--- a/contracts/KetherNFT.sol
+++ b/contracts/KetherNFT.sol
@@ -2,12 +2,10 @@
 pragma solidity >=0.8.4;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import '@openzeppelin/contracts/utils/Strings.sol';
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 import "./IKetherHomepage.sol";
-import "base64-sol/base64.sol";
-
-import "hardhat/console.sol"; // XXX
+import "./KetherNFTRender.sol";
 
 
 // TODO: Name this something really cool
@@ -20,22 +18,19 @@ contract Wrapper {
   }
 }
 
-contract KetherNFT is ERC721 {
-  using Strings for uint;
-
+contract KetherNFT is ERC721, Ownable {
   /// instance is the KetherHomepage contract that this wrapper interfaces with.
   IKetherHomepage public instance;
-
-  /// admin controls upgrading the tokenURI renderer and releasing trapped funds.
-  address admin;
 
   /// disableRenderUpgrade is whether we can still upgrade the tokenURI renderer.
   /// Once it is set it cannot be unset.
   // TODO: bool disableRenderUpgrade = false;
 
-  constructor(address _ketherContract, address _admin) ERC721("Thousand Ether Homepage Ad", "1KAD") {
+  ITokenRenderer public renderer;
+
+  constructor(address _ketherContract, address _renderer) ERC721("Thousand Ether Homepage Ad", "1KAD") {
     instance = IKetherHomepage(_ketherContract);
-    admin = _admin;
+    renderer = ITokenRenderer(_renderer);
   }
 
   function _encodeWrapper(uint _idx) internal view returns (bytes memory) {
@@ -94,33 +89,9 @@ contract KetherNFT is ERC721 {
     _burn(_idx);
   }
 
-  function _renderNFTImage(uint x, uint y, uint width, uint height) internal pure returns (string memory) {
-    return Base64.encode(bytes(abi.encodePacked(
-      '<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><g>',
-      '<rect x="',x.toString(),'" y="',y.toString(),'" width="',width.toString(),'" height="',height.toString(),'" fill="orange"></rect>',
-      '</g></svg>')));
-  }
-
   function tokenURI(uint256 tokenId) public view override(ERC721) returns (string memory) {
     require(_exists(tokenId), "KetherNFT: tokenId does not exist");
-
-    (,uint x,uint y,uint width,uint height,,,,,) = instance.ads(tokenId);
-
-    // TODO: return tokenRenderer.tokenURI(this, tokenId);
-    return string(
-      abi.encodePacked(
-        'data:application/json;base64,',
-        Base64.encode(bytes(abi.encodePacked(
-              '{"name":"Thousand Ether Homepage Ad: ',
-              width.toString(), 'x', height.toString(), ' at [', x.toString(), ',', y.toString(), ']',
-              '", "description":"This NFT represents an ad unit on https://1000ether.com/, the owner of the NFT controls the content of this ad unit.',
-              '", "image": "data:image/svg+xml;base64,',
-              _renderNFTImage(x, y, width, height),
-              '"}'
-        )))
-      )
-    );
-
+    return renderer.tokenURI(instance, tokenId);
   }
 
   /// publish is a delegated proxy for KetherHomapage's publish function.
@@ -148,14 +119,15 @@ contract KetherNFT is ERC721 {
   /// there is a bug in the DApp that somehow falls into this condition.
   /// Note that this function does *not* give admin any control over properly
   /// minted ads/NFTs.
-  function adminRecoverTrapped(uint _idx, address _to) external {
-    require(_msgSender() == admin, "KetherNFT: recovery must be done by admin");
+  function adminRecoverTrapped(uint _idx, address _to) external onlyOwner {
     require(!_exists(_idx), "KetherNFT: recovery can only be done on unminted ads");
     require(_getAdOwner(_idx) == address(this), "KetherNFT: ad not held by contract");
-
     instance.setAdOwner(_idx, _to);
   }
 
-  // TODO: adminTransfer
-  // TODO: adminDisableRenderUpgrade
+  function adminSetRenderer(address _renderer) external onlyOwner {
+    renderer = ITokenRenderer(_renderer);
+  }
+
+  // TODO: adminDisableRenderUpgrade?
 }

--- a/contracts/KetherNFT.sol
+++ b/contracts/KetherNFT.sol
@@ -86,7 +86,7 @@ contract KetherNFT is ERC721 {
   }
 
   function unwrap(uint _idx, address _newOwner) external {
-    require(ownerOf(_idx) == _msgSender(), "KetherNFT: unwrap for sender that is not owner");
+    require(_isApprovedOrOwner(_msgSender(), _idx), "KetherNFT: unwrap for sender that is not owner");
 
     instance.setAdOwner(_idx, _newOwner);
     require(_getAdOwner(_idx) == _newOwner, "KetherNFT: unwrap ownership transfer failed");

--- a/contracts/KetherNFT.sol
+++ b/contracts/KetherNFT.sol
@@ -89,6 +89,8 @@ contract KetherNFT is ERC721, Ownable {
     _burn(_idx);
   }
 
+  function baseURI() public pure override returns (string memory) {}
+
   function tokenURI(uint256 tokenId) public view override(ERC721) returns (string memory) {
     require(_exists(tokenId), "KetherNFT: tokenId does not exist");
     return renderer.tokenURI(instance, tokenId);

--- a/contracts/KetherNFTRender.sol
+++ b/contracts/KetherNFTRender.sol
@@ -1,0 +1,41 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.8.4;
+
+import '@openzeppelin/contracts/utils/Strings.sol';
+
+import "./IKetherHomepage.sol";
+
+import "base64-sol/base64.sol";
+
+interface ITokenRenderer {
+    function tokenURI(IKetherHomepage instance, uint256 tokenId) external view returns (string memory);
+}
+
+contract KetherNFTRender is ITokenRenderer {
+  using Strings for uint;
+
+  function _renderNFTImage(uint x, uint y, uint width, uint height) internal pure returns (string memory) {
+    return Base64.encode(bytes(abi.encodePacked(
+      '<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><g>',
+      '<rect x="',x.toString(),'" y="',y.toString(),'" width="',width.toString(),'" height="',height.toString(),'" fill="orange"></rect>',
+      '</g></svg>')));
+  }
+
+  function tokenURI(IKetherHomepage instance, uint256 tokenId) public view override(ITokenRenderer) returns (string memory) {
+    (,uint x,uint y,uint width,uint height,,,,,) = instance.ads(tokenId);
+
+    return string(
+      abi.encodePacked(
+        'data:application/json;base64,',
+        Base64.encode(bytes(abi.encodePacked(
+              '{"name":"Thousand Ether Homepage Ad: ',
+              width.toString(), 'x', height.toString(), ' at [', x.toString(), ',', y.toString(), ']',
+              '", "description":"This NFT represents an ad unit on https://1000ether.com/, the owner of the NFT controls the content of this ad unit.',
+              '", "image": "data:image/svg+xml;base64,',
+              _renderNFTImage(x, y, width, height),
+              '"}'
+        )))
+      )
+    );
+  }
+}

--- a/contracts/KetherNFTRender.sol
+++ b/contracts/KetherNFTRender.sol
@@ -24,16 +24,24 @@ contract KetherNFTRender is ITokenRenderer {
   function tokenURI(IKetherHomepage instance, uint256 tokenId) public view override(ITokenRenderer) returns (string memory) {
     (,uint x,uint y,uint width,uint height,,,,,) = instance.ads(tokenId);
 
+    // Units are 1/10
+    x *= 10;
+    y *= 10;
+    width *= 10;
+    height *= 10;
+
+    // TODO: Add NSFW property
+
     return string(
       abi.encodePacked(
         'data:application/json;base64,',
         Base64.encode(bytes(abi.encodePacked(
-              '{"name":"Thousand Ether Homepage Ad: ',
-              width.toString(), 'x', height.toString(), ' at [', x.toString(), ',', y.toString(), ']',
-              '", "description":"This NFT represents an ad unit on https://1000ether.com/, the owner of the NFT controls the content of this ad unit.',
-              '", "image": "data:image/svg+xml;base64,',
-              _renderNFTImage(x, y, width, height),
-              '"}'
+              '{"name":"Thousand Ether Homepage Ad: ', width.toString(), 'x', height.toString(), ' at [', x.toString(), ',', y.toString(), ']"',
+              ',"description":"This NFT represents an ad unit on thousandetherhomepage.com, the owner of the NFT controls the content of this ad unit."',
+              ',"external_url":"https://thousandetherhomepage.com"',
+              ',"image":"data:image/svg+xml;base64,', _renderNFTImage(x, y, width, height), '"',
+              ',"properties":{"width":', width.toString(),',"height":',height.toString(),'}',
+              '}'
         )))
       )
     );

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,5 +1,6 @@
 require("@nomiclabs/hardhat-waffle");
 require("hardhat-gas-reporter");
+require("@nomiclabs/hardhat-etherscan");
 
 const INFURA_API_KEY = process.env['INFURA_API_KEY'];
 
@@ -23,6 +24,9 @@ module.exports = {
       url: 'https://mainnet.infura.io/v3/' + INFURA_API_KEY,
       accounts: ACCOUNTS,
     }
+  },
+  etherscan: {
+    apiKey: process.env['ETHERSCAN_API_KEY']
   },
   solidity: {
     compilers: [

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -27,17 +27,20 @@ module.exports = {
   solidity: {
     compilers: [
       {
-        // Original KetherHomepage contract
-        version: "0.4.15",
+        version: "0.8.4",
       },
       {
-        version: "0.8.0",
+        // Original KetherHomepage contract
+        version: "0.4.15",
       },
     ],
   },
   gasReporter: {
+    enabled: (process.env.REPORT_GAS) ? true : false,
     currency: 'USD',
-    gasPrice: 21
+    // Note: Prices are hardcoded for now
+    gasPrice: 21,
+    ethPrice: 3500,
   },
 };
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -27,12 +27,12 @@ module.exports = {
     compilers: [
       {
         // Original KetherHomepage contract
-        version: "0.4.15"
+        version: "0.4.15",
       },
       {
-        version: "0.7.3",
-      }
-    ]
-  }
+        version: "0.8.0",
+      },
+    ],
+  },
 };
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,4 +1,5 @@
 require("@nomiclabs/hardhat-waffle");
+require("hardhat-gas-reporter");
 
 const INFURA_API_KEY = process.env['INFURA_API_KEY'];
 
@@ -33,6 +34,10 @@ module.exports = {
         version: "0.8.0",
       },
     ],
+  },
+  gasReporter: {
+    currency: 'USD',
+    gasPrice: 21
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -992,6 +992,12 @@
         "@types/web3": "1.0.19"
       }
     },
+    "@openzeppelin/contracts": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.0.0.tgz",
+      "integrity": "sha512-UcIJl/vUVjTr3H1yYXZi7Sr2PlXzBEHVUJKOUlVyzyy0FI8oQCCy0Wx+BuK/fojdnmLeMvUk4KUvhKUybP+C7Q==",
+      "dev": true
+    },
     "@resolver-engine/core": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@resolver-engine/core/-/core-0.3.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1273,6 +1273,24 @@
       "integrity": "sha512-vI5iOAsez9+roLS3M3+Xx7w+WRuDtSmF8bQkrbcIJ2sC1PcDgVoA0WGpa+bIrJ+y8zqY2oi//fUctkxtIcXJCw==",
       "dev": true
     },
+    "@types/concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/form-data": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+      "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/levelup": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/levelup/-/levelup-4.3.1.tgz",
@@ -1338,6 +1356,12 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.3.tgz",
       "integrity": "sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==",
+      "dev": true
+    },
+    "@types/qs": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==",
       "dev": true
     },
     "@types/resolve": {
@@ -1707,6 +1731,12 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
     "asn1": {
@@ -2614,6 +2644,24 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "blakejs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
@@ -2710,6 +2758,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
     },
     "browserify-aes": {
       "version": "1.2.0",
@@ -3070,6 +3124,12 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -3211,6 +3271,17 @@
       "dev": true,
       "requires": {
         "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-table3": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.1.2",
+        "object-assign": "^4.1.0",
+        "string-width": "^2.1.1"
       }
     },
     "cli-width": {
@@ -3621,6 +3692,12 @@
         "which": "^1.2.9"
       }
     },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
+    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -4019,6 +4096,12 @@
       "integrity": "sha512-qi86tE6hRcFHy8jI1m2VG+LaPUR1LhqDa5G8tVjuUXmOrpuAgqsA1pN0+ldgr3aKUH+QLI9hCY/OcRYisERejw==",
       "dev": true
     },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -4131,6 +4214,17 @@
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
+      }
+    },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "dev": true,
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
       }
     },
     "duplexer3": {
@@ -4673,6 +4767,163 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
           "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        }
+      }
+    },
+    "eth-gas-reporter": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/eth-gas-reporter/-/eth-gas-reporter-0.2.22.tgz",
+      "integrity": "sha512-L1FlC792aTf3j/j+gGzSNlGrXKSxNPXQNk6TnV5NNZ2w3jnQCRyJjDl0zUo25Cq2t90IS5vGdbkwqFQK7Ce+kw==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abi": "^5.0.0-beta.146",
+        "@solidity-parser/parser": "^0.12.0",
+        "cli-table3": "^0.5.0",
+        "colors": "^1.1.2",
+        "ethereumjs-util": "6.2.0",
+        "ethers": "^4.0.40",
+        "fs-readdir-recursive": "^1.1.0",
+        "lodash": "^4.17.14",
+        "markdown-table": "^1.1.3",
+        "mocha": "^7.1.1",
+        "req-cwd": "^2.0.0",
+        "request": "^2.88.0",
+        "request-promise-native": "^1.0.5",
+        "sha1": "^1.1.1",
+        "sync-request": "^6.0.0"
+      },
+      "dependencies": {
+        "@solidity-parser/parser": {
+          "version": "0.12.2",
+          "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.12.2.tgz",
+          "integrity": "sha512-d7VS7PxgMosm5NyaiyDJRNID5pK4AWj1l64Dbz0147hJgy5k2C0/ZiKK/9u5c5K+HRUVHmp+RMvGEjGh84oA5Q==",
+          "dev": true
+        },
+        "@types/bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "ethereumjs-util": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
+          "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "0.1.6",
+            "keccak": "^2.0.0",
+            "rlp": "^2.2.3",
+            "secp256k1": "^3.0.1"
+          }
+        },
+        "ethers": {
+          "version": "4.0.48",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
+          "integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
+          "dev": true,
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.5.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.3",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            }
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "keccak": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
+          "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+          "dev": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "inherits": "^2.0.4",
+            "nan": "^2.14.0",
+            "safe-buffer": "^5.2.0"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
+          "dev": true
+        },
+        "secp256k1": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+          "dev": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "bip66": "^1.1.5",
+            "bn.js": "^4.11.8",
+            "create-hash": "^1.2.0",
+            "drbg.js": "^1.0.1",
+            "elliptic": "^6.5.2",
+            "nan": "^2.14.0",
+            "safe-buffer": "^5.1.2"
+          }
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+          "dev": true
         }
       }
     },
@@ -5491,6 +5742,12 @@
         "loader-utils": "~0.2.5"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -5704,6 +5961,12 @@
       "requires": {
         "minipass": "^2.6.0"
       }
+    },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -14684,6 +14947,12 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "get-port": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
+      "dev": true
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -14803,6 +15072,12 @@
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
     },
     "handle-thing": {
       "version": "2.0.1",
@@ -15493,6 +15768,16 @@
         }
       }
     },
+    "hardhat-gas-reporter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hardhat-gas-reporter/-/hardhat-gas-reporter-1.0.4.tgz",
+      "integrity": "sha512-G376zKh81G3K9WtDA+SoTLWsoygikH++tD1E7llx+X7J+GbIqfwhDKKgvJjcnEesMrtR9UqQHK02lJuXY1RTxw==",
+      "dev": true,
+      "requires": {
+        "eth-gas-reporter": "^0.2.20",
+        "sha1": "^1.1.1"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -15783,6 +16068,18 @@
         }
       }
     },
+    "http-basic": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-8.1.3.tgz",
+      "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
+      "dev": true,
+      "requires": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^1.6.2",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      }
+    },
     "http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
@@ -15845,6 +16142,23 @@
         "is-glob": "^4.0.0",
         "lodash": "^4.17.11",
         "micromatch": "^3.1.10"
+      }
+    },
+    "http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^10.0.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.59",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.59.tgz",
+          "integrity": "sha512-7Uc8IRrL8yZz5ti45RaFxpbU8TxlzdC3HvxV+hOWo1EyLsuKv/w7y0n+TwZzwL3vdx3oZ2k3ubxPq131hNtXyg==",
+          "dev": true
+        }
       }
     },
     "http-signature": {
@@ -16532,6 +16846,12 @@
         }
       }
     },
+    "js-sha3": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+      "dev": true
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -17092,6 +17412,12 @@
         "object-visit": "^1.0.0"
       }
     },
+    "markdown-table": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
+      "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
+      "dev": true
+    },
     "math-expression-evaluator": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.3.7.tgz",
@@ -17592,6 +17918,308 @@
       "dev": true,
       "requires": {
         "obliterator": "^1.6.1"
+      }
+    },
+    "mocha": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+      "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.3.0",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "3.0.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.5",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.6",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "1.6.0"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+          "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "chokidar": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+          "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+          "dev": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.1",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.2.0"
+          }
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "dev": true,
+          "optional": true
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "object.assign": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+          "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.0",
+            "object-keys": "^1.0.11"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "readdirp": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+          "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+          "dev": true,
+          "requires": {
+            "picomatch": "^2.0.4"
+          }
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     },
     "mock-fs": {
@@ -18313,6 +18941,12 @@
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104=",
+      "dev": true
     },
     "parse-headers": {
       "version": "2.0.3",
@@ -19302,6 +19936,15 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
+      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
+      "dev": true,
+      "requires": {
+        "asap": "~2.0.6"
+      }
+    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -19670,6 +20313,32 @@
         "is-finite": "^1.0.0"
       }
     },
+    "req-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-2.0.0.tgz",
+      "integrity": "sha1-1AgrTURZgDZkD7c93qAe1T20nrw=",
+      "dev": true,
+      "requires": {
+        "req-from": "^2.0.0"
+      }
+    },
+    "req-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/req-from/-/req-from-2.0.0.tgz",
+      "integrity": "sha1-10GI5H+TeW9Kpx327jWuaJ8+DnA=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
+      }
+    },
     "request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
@@ -19695,6 +20364,26 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.19"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
       }
     },
     "require-directory": {
@@ -20285,6 +20974,16 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "sha1": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
+      "integrity": "sha1-rdqnqTFo85PxnrKxUJFhjicA+Eg=",
+      "dev": true,
+      "requires": {
+        "charenc": ">= 0.0.1",
+        "crypt": ">= 0.0.1"
+      }
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -20726,6 +21425,12 @@
         "readable-stream": "^2.0.1"
       }
     },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
+    },
     "stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -20990,6 +21695,26 @@
         }
       }
     },
+    "sync-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
+      "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
+      "dev": true,
+      "requires": {
+        "http-response-object": "^3.0.1",
+        "sync-rpc": "^1.2.1",
+        "then-request": "^6.0.0"
+      }
+    },
+    "sync-rpc": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.6.tgz",
+      "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
+      "dev": true,
+      "requires": {
+        "get-port": "^3.1.0"
+      }
+    },
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
@@ -21090,6 +21815,33 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "then-request": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
+      "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
+      "dev": true,
+      "requires": {
+        "@types/concat-stream": "^1.6.0",
+        "@types/form-data": "0.0.33",
+        "@types/node": "^8.0.0",
+        "@types/qs": "^6.2.31",
+        "caseless": "~0.12.0",
+        "concat-stream": "^1.6.0",
+        "form-data": "^2.2.0",
+        "http-basic": "^8.1.1",
+        "http-response-object": "^3.0.1",
+        "promise": "^8.0.0",
+        "qs": "^6.4.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.10.66",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+          "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
+          "dev": true
+        }
+      }
     },
     "through": {
       "version": "2.3.8",
@@ -22017,6 +22769,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -23282,6 +24035,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -23723,6 +24477,12 @@
       "requires": {
         "cookiejar": "^2.1.1"
       }
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -982,6 +982,64 @@
       "integrity": "sha512-6quxWe8wwS4X5v3Au8q1jOvXYEPkS1Fh+cME5u6AwNdnI4uERvPlVjlgRWzpnb+Rrt1l/cEqiNRH9GlsBMSDQg==",
       "dev": true
     },
+    "@nomiclabs/hardhat-etherscan": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-2.1.2.tgz",
+      "integrity": "sha512-SExzaBuHlnmHw0HKkElHITzdvhUQmlIRc2tlaywzgvPbh7WoI24nYqZ4N0CO+JXSDgRpFycvQNA8zRaCqjuqUg==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abi": "^5.0.2",
+        "@ethersproject/address": "^5.0.2",
+        "cbor": "^5.0.2",
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.1",
+        "node-fetch": "^2.6.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "@nomiclabs/hardhat-waffle": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-waffle/-/hardhat-waffle-2.0.1.tgz",
@@ -2643,6 +2701,12 @@
       "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
       "dev": true
     },
+    "bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
+      "dev": true
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -3085,6 +3149,16 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "cbor": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
+      "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "^9.0.1",
+        "nofilter": "^1.0.4"
+      }
     },
     "center-align": {
       "version": "0.1.3",
@@ -14328,7 +14402,7 @@
               }
             },
             "ethereumjs-abi": {
-              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1a27c59c15ab1e95ee8e5c4ed6ad814c49cc439e",
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
               "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "dev": true,
               "requires": {
@@ -18527,6 +18601,12 @@
           }
         }
       }
+    },
+    "nofilter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
+      "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==",
+      "dev": true
     },
     "nopt": {
       "version": "3.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2612,6 +2612,11 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
+    "base64-sol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/base64-sol/-/base64-sol-1.0.1.tgz",
+      "integrity": "sha512-ld3cCNMeXt4uJXmLZBHFGMvVpK9KsLVEhPpFRXnvSVAqABKbuNZg/+dsq3NuM+wxFLb/UrVkz7m1ciWmkMfTbg=="
+    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",
+    "@nomiclabs/hardhat-etherscan": "^2.1.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^4.0.0",
     "babel-core": "^6.26.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ethers": "^5.1.3",
     "file-loader": "^0.9.0",
     "hardhat": "^2.2.0",
+    "hardhat-gas-reporter": "^1.0.4",
     "html-webpack-plugin": "^2.30.1",
     "json-loader": "^0.5.7",
     "node-sass": "^4.9.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
+    "@openzeppelin/contracts": "^4.0.0",
     "babel-core": "^6.26.3",
     "babel-loader": "^6.0.0",
     "babel-preset-env": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "base64-sol": "^1.0.1",
     "vue": "^2.4.4",
     "vue-draggable-resizable": "^1.5.1",
     "vuex": "^2.4.1",

--- a/scripts/deployKetherNFT.js
+++ b/scripts/deployKetherNFT.js
@@ -5,6 +5,8 @@ const deployed = {
   'rinkeby': {
     ownerAddress: "0x961Aa96FebeE5465149a0787B03bFa14D8e9033F",
     ketherHomepageAddress: "0xb88404dd8fe4969ef67841250baef7f04f6b1a5e",
+    ketherNFTRendererAddress: "0xA6fE3123bE665C716F71944705ecC8057E35cd90",
+    ketherNFTAddress: "0xd81620fc592c6DC4104FAa9bec1E1e5F5562d8fd",
   },
   'mainnet': {
     ownerAddress: "0xd534d9f6e61780b824afaa68032a7ec11720ca12",
@@ -35,15 +37,32 @@ async function main() {
   } else if (account.address === cfg.ownerAddress) {
     throw "Did not acquire signer for owner address: " + cfg.ownerAddress;
   }
+  console.log("Starting deploys from address:", account.address);
 
   const KetherNFT = await ethers.getContractFactory("KetherNFT");
   const KetherNFTRender = await ethers.getContractFactory("KetherNFTRender");
 
-  const KNFTrender = await KetherNFTRender.deploy();
-  console.log("Deployed KetherNFTRender to:", KNFTrender.address);
+  let ketherNFTRendererAddress = cfg["ketherNFTRendererAddress"];
+  if (ketherNFTRendererAddress === undefined) {
+    const KNFTrender = await KetherNFTRender.deploy();
+    console.log("Deploying KetherNFTRender to:", KNFTrender.address);
+    ketherNFTRendererAddress = KNFTrender.address;
 
-  const KNFT = await KetherNFT.deploy(KH.address, KNFTrender.address);
-  console.log("Deployed KetherNFT to:", KNFT.address);
+    const tx = await KNFTrender.deployTransaction.wait();
+    console.log(" -> Mined with", tx.gasUsed.toString(), "gas");
+  } else {
+    console.log("KetherNFTRender already deployed");
+  }
+
+  if (cfg["ketherNFTAddress"] === undefined) {
+    const KNFT = await KetherNFT.deploy(KH.address, ketherNFTRendererAddress);
+    console.log("Deploying KetherNFT to:", KNFT.address);
+
+    const tx = await KNFT.deployTransaction.wait();
+    console.log(" -> Mined with", tx.gasUsed.toString(), "gas");
+  } else {
+    console.log("KetherNFT already deployed");
+  }
 }
 
 main()

--- a/scripts/deployKetherNFT.js
+++ b/scripts/deployKetherNFT.js
@@ -1,0 +1,54 @@
+const hre = require("hardhat");
+const ethers = hre.ethers;
+
+const deployed = {
+  'rinkeby': {
+    ownerAddress: "0x961Aa96FebeE5465149a0787B03bFa14D8e9033F",
+    ketherHomepageAddress: "0xb88404dd8fe4969ef67841250baef7f04f6b1a5e",
+  },
+  'mainnet': {
+    ownerAddress: "0xd534d9f6e61780b824afaa68032a7ec11720ca12",
+    ketherHomepageAddress: "0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
+  },
+};
+
+deployed['homestead'] = deployed['mainnet']; // Alias for ethers
+
+async function main() {
+  const network = await ethers.provider.getNetwork();
+  const cfg = deployed[network.name];
+
+  if (cfg === undefined) {
+    throw "Unsupported network: "+ network.name;
+  }
+
+  if (network.name !== 'rinkeby') {
+    throw "Only rinkeby allowed by default";
+  }
+
+  // Confirm the contract is actually there
+  const KH = await ethers.getContractAt("KetherHomepage", cfg.ketherHomepageAddress);
+
+  const [account] = await ethers.getSigners();
+  if (account === undefined) {
+    throw "Signer account not provided, specify ACCOUNT_PRIVATE_KEY";
+  } else if (account.address === cfg.ownerAddress) {
+    throw "Did not acquire signer for owner address: " + cfg.ownerAddress;
+  }
+
+  const KetherNFT = await ethers.getContractFactory("KetherNFT");
+  const KetherNFTRender = await ethers.getContractFactory("KetherNFTRender");
+
+  const KNFTrender = await KetherNFTRender.deploy();
+  console.log("Deployed KetherNFTRender to:", KNFTrender.address);
+
+  const KNFT = await KetherNFT.deploy(KH.address, KNFTrender.address);
+  console.log("Deployed KetherNFT to:", KNFT.address);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/test/ketherhomepage.js
+++ b/test/ketherhomepage.js
@@ -1,12 +1,12 @@
 const { expect } = require('chai');
 
-describe('KetherHomepage', function(accounts) {
-  let KetherHomagepage;
+// TODO: should we query the contract to make sure the above values are right?
+const weiPixelPrice = ethers.utils.parseUnits("0.001", "ether");
+const pixelsPerCell = ethers.BigNumber.from(100);
+const oneHundredCellPrice = pixelsPerCell.mul(weiPixelPrice).mul(100);
 
-  // TODO: should we query the contract to make sure the above values are right?
-  const weiPixelPrice = ethers.utils.parseUnits("0.001", "ether");
-  const pixelsPerCell = ethers.BigNumber.from(100);
-  const oneHundredCellPrice = pixelsPerCell.mul(weiPixelPrice).mul(100);
+describe('KetherHomepage', function() {
+  let KetherHomagepage;
 
   let owner, withdrawWallet, account1, account2;
   before(async () => {

--- a/test/kethernft.js
+++ b/test/kethernft.js
@@ -1,0 +1,38 @@
+const { expect } = require('chai');
+
+const weiPixelPrice = ethers.utils.parseUnits("0.001", "ether");
+const pixelsPerCell = ethers.BigNumber.from(100);
+const oneHundredCellPrice = pixelsPerCell.mul(weiPixelPrice).mul(100);
+
+describe('KetherNFT', function() {
+  it("deploy KetherNFT", async function() {
+    const KetherHomepage = await ethers.getContractFactory("KetherHomepage");
+    const [owner, withdrawWallet, metadataSigner, account1, account2] = await ethers.getSigners();
+    const KH = await KetherHomepage.deploy(await owner.getAddress(), await withdrawWallet.getAddress());
+
+    const KetherNFT = await ethers.getContractFactory("KetherNFT");
+
+    const KNFT = await KetherNFT.deploy(KH.address, await metadataSigner.getAddress());
+
+    // Buy an ad
+    const txn = await KH.connect(account1).buy(0, 0, 10, 10, { value: oneHundredCellPrice });
+    const receipt = await txn.wait();
+    const event = receipt.events.pop();
+    const [idx] = event.args;
+    expect(idx).to.equal(0);
+
+    await KH.connect(account1).publish(idx, "link", "image", "title", false);
+
+    // Wrap ad
+    await KNFT.connect(account1).wrap(idx);
+
+    // Confirm owner can't publish directly anymore
+    expect(
+      KH.connect(account1).publish(idx, "foo", "bar", "baaz", false)
+    ).to.revert;
+
+    const ad = await KH.ads(idx);
+    expect(ad).to.equal([await account1.getAddress(), 0, 0, 10, 10, idx, "link", "image", "title", false, false]);
+  });
+});
+

--- a/test/kethernft.js
+++ b/test/kethernft.js
@@ -23,8 +23,19 @@ describe('KetherNFT', function() {
 
     await KH.connect(account1).publish(idx, "link", "image", "title", false);
 
+    // TODO: Test wrapping to non-owner
+    // TODO: Test wrapping by non-owner
+
+    const [salt, precomputeAddress] = await KNFT.connect(account1).precompute(idx, await account1.getAddress());
+
+    // TODO: Check precompute in js
+    expect(precomputeAddress).to.not.equal("0x0");
+    expect(salt).to.not.equal("0x0");
+
+    await KH.connect(account1).setAdOwner(idx, precomputeAddress);
+
     // Wrap ad
-    await KNFT.connect(account1).wrap(idx);
+    await KNFT.connect(account1).wrap(idx, await account1.getAddress());
 
     // Confirm owner can't publish directly anymore
     expect(
@@ -32,7 +43,7 @@ describe('KetherNFT', function() {
     ).to.revert;
 
     const ad = await KH.ads(idx);
-    expect(ad).to.equal([await account1.getAddress(), 0, 0, 10, 10, idx, "link", "image", "title", false, false]);
+    expect(ad).to.equal([await KNFT.getAddress(), 0, 0, 10, 10, idx, "link", "image", "title", false, false]);
   });
 });
 

--- a/test/kethernft.js
+++ b/test/kethernft.js
@@ -7,7 +7,7 @@ const pixelsPerCell = ethers.BigNumber.from(100);
 const oneHundredCellPrice = pixelsPerCell.mul(weiPixelPrice).mul(100);
 
 describe('KetherNFT', function() {
-  let KetherHomepage, KetherNFT, KetherNFTRender, Wrapper;
+  let KetherHomepage, KetherNFT, KetherNFTRender, FlashEscrow;
   let accounts, KH, KNFT, KNFTrender;
 
   beforeEach(async() => {
@@ -15,8 +15,7 @@ describe('KetherNFT', function() {
     KetherHomepage = await ethers.getContractFactory("KetherHomepageV2");
     KetherNFT = await ethers.getContractFactory("KetherNFT");
     KetherNFTRender = await ethers.getContractFactory("KetherNFTRender");
-    Wrapper = await ethers.getContractFactory("Wrapper");
-
+    FlashEscrow = await ethers.getContractFactory("FlashEscrow");
 
     const [owner, withdrawWallet, metadataSigner, account1, account2, account3] = await ethers.getSigners();
     accounts = {owner, withdrawWallet, metadataSigner, account1, account2, account3};
@@ -219,8 +218,8 @@ describe('KetherNFT', function() {
 
     const bytecode = ethers.utils.hexlify(
       ethers.utils.concat([
-        Wrapper.bytecode,
-        Wrapper.interface.encodeDeploy([KH.address, wrappedPayload]),
+        FlashEscrow.bytecode,
+        FlashEscrow.interface.encodeDeploy([KH.address, wrappedPayload]),
         // Same as: ethers.utils.defaultAbiCoder.encode(['address', 'bytes'], [KH.address, wrappedPayload]),
       ]));
 

--- a/test/kethernft.js
+++ b/test/kethernft.js
@@ -119,7 +119,7 @@ describe('KetherNFT', function() {
 
   it("should generate tokenURI based on wrapped ad", async function() {
     const {account1, account2} = accounts;
-    const idx = await buyAd(account1);
+    const idx = await buyAd(account1, 1, 2, 3, 4);
     const [salt, precomputeAddress] = await KNFT.connect(account1).precompute(idx, await account1.getAddress());
 
     await KH.connect(account1).publish(idx, "link", "image", "title", false);
@@ -129,9 +129,11 @@ describe('KetherNFT', function() {
 
     {
       const expected = {
-        "name": "Thousand Ether Homepage Ad: 10x10 at [0,0]",
-        "description": "This NFT represents an ad unit on https://1000ether.com/, the owner of the NFT controls the content of this ad unit.",
+        "name": "Thousand Ether Homepage Ad: 30x40 at [10,20]",
+        "description": "This NFT represents an ad unit on thousandetherhomepage.com, the owner of the NFT controls the content of this ad unit.",
+        "external_url": "https://thousandetherhomepage.com",
         "image": "omitted for testing", // TODO: Test image elsewhere
+        "properties": {"width": 30, "height": 40},
       };
       const r = await KNFT.connect(account1).tokenURI(idx);
       const prefix = 'data:application/json;base64';
@@ -139,7 +141,13 @@ describe('KetherNFT', function() {
 
       const got = Buffer.from(r.slice(prefix.length), 'base64').toString();
 
-      const parsed = JSON.parse(got);
+      let parsed;
+      try {
+        parsed = JSON.parse(got);
+      } catch (e) {
+        console.log("Failed to parse:", got);
+        throw e;
+      }
       expect(parsed['image']).to.have.string('data:image/svg+xml;base64,');
 
       parsed['image'] = expected['image'];

--- a/test/kethernft.js
+++ b/test/kethernft.js
@@ -6,7 +6,7 @@ const oneHundredCellPrice = pixelsPerCell.mul(weiPixelPrice).mul(100);
 
 describe('KetherNFT', function() {
   it("deploy KetherNFT", async function() {
-    const KetherHomepage = await ethers.getContractFactory("KetherHomepage");
+    const KetherHomepage = await ethers.getContractFactory("KetherHomepageV2");
     const [owner, withdrawWallet, metadataSigner, account1, account2] = await ethers.getSigners();
     const KH = await KetherHomepage.deploy(await owner.getAddress(), await withdrawWallet.getAddress());
 

--- a/test/kethernft.js
+++ b/test/kethernft.js
@@ -7,13 +7,14 @@ const pixelsPerCell = ethers.BigNumber.from(100);
 const oneHundredCellPrice = pixelsPerCell.mul(weiPixelPrice).mul(100);
 
 describe('KetherNFT', function() {
-  let KetherHomepage, KetherNFT, Wrapper;
-  let accounts, KH, KNFT;
+  let KetherHomepage, KetherNFT, KetherNFTRender, Wrapper;
+  let accounts, KH, KNFT, KNFTrender;
 
   beforeEach(async() => {
     // NOTE: We're using V2 here because it's ported to newer solidity so we can debug more easily. It should also work with V1.
     KetherHomepage = await ethers.getContractFactory("KetherHomepageV2");
     KetherNFT = await ethers.getContractFactory("KetherNFT");
+    KetherNFTRender = await ethers.getContractFactory("KetherNFTRender");
     Wrapper = await ethers.getContractFactory("Wrapper");
 
 
@@ -21,7 +22,8 @@ describe('KetherNFT', function() {
     accounts = {owner, withdrawWallet, metadataSigner, account1, account2, account3};
 
     KH = await KetherHomepage.deploy(await owner.getAddress(), await withdrawWallet.getAddress());
-    KNFT = await KetherNFT.deploy(KH.address, await metadataSigner.getAddress());
+    KNFTrender = await KetherNFTRender.deploy();
+    KNFT = await KetherNFT.deploy(KH.address, KNFTrender.address);
   });
 
   const buyAd = async function(account, x=0, y=0, width=10, height=10, link="link", image="image", title="title", NSFW=false, value=oneHundredCellPrice) {

--- a/test/kethernft.js
+++ b/test/kethernft.js
@@ -60,8 +60,13 @@ describe('KetherNFT', function() {
       KH.connect(account1).publish(idx, "foo", "bar", "baaz", false)
     ).to.reverted;
 
-    const ad = await KH.ads(idx);
-    //expect(ad).to.eql([await KNFT.address, BN(0), BN(0), BN(10), BN(10), "link", "image", "title", false, false]);
+    {
+      const [addr,,,,,link,image,title] = await KH.ads(idx);
+      expect(addr).to.equal(KNFT.address);
+      expect(link).to.equal("link");
+      expect(image).to.equal("image");
+      expect(title).to.equal("title");
+    }
   });
 });
 

--- a/test/kethernft.js
+++ b/test/kethernft.js
@@ -33,7 +33,7 @@ describe('KetherNFT', function() {
     return idx;
   }
 
-  it("wrap ad with KetherNFT", async function() {
+  it("should wrap ad with KetherNFT", async function() {
     const {account1} = accounts;
 
     // Buy an ad
@@ -62,19 +62,19 @@ describe('KetherNFT', function() {
     }
 
     // Confirm NFT owner can publish through the NFT
-    await KNFT.connect(account1).publish(idx, "foo2", "bar2", "baaz2", false);
+    await KNFT.connect(account1).publish(idx, "foo2", "baar2", "baaz2", false);
 
     {
       const [addr,,,,,link,image,title] = await KH.ads(idx);
       expect(addr).to.equal(KNFT.address);
       expect(link).to.equal("foo2");
-      expect(image).to.equal("bar2");
+      expect(image).to.equal("baar2");
       expect(title).to.equal("baaz2");
     }
 
   });
 
-  it('wrap to non-owner', async function() {
+  it('should wrap to non-owner', async function() {
     const {account1, account2, account3} = accounts;
     const idx = await buyAd(account1);
     {
@@ -115,22 +115,20 @@ describe('KetherNFT', function() {
 
   });
 
-  it("change tokenURI after wrapping", async function() {
+  it("should change tokenURI after wrapping", async function() {
     const {account1, account2} = accounts;
     const idx = await buyAd(account1);
     const [salt, precomputeAddress] = await KNFT.connect(account1).precompute(idx, await account1.getAddress());
 
+    await KH.connect(account1).publish(idx, "link", "image", "title", false);
     await KH.connect(account1).setAdOwner(idx, precomputeAddress);
+
     await KNFT.connect(account1).wrap(idx, await account1.getAddress());
-    await KNFT.connect(account1).setTokenURI(idx, "foo");
 
     expect(await KNFT.connect(account1).tokenURI(idx)).to.equal("foo");
-    await expect(
-      KNFT.connect(account2).setTokenURI(idx, "bar")
-    ).to.be.revertedWith("KetherNFT: setTokenURI for sender that is not approved")
   });
 
-  it("unwrap", async function() {
+  it("should unwrap", async function() {
     const {account1, account2} = accounts;
     const idx = await buyAd(account1);
     const [salt, precomputeAddress] = await KNFT.connect(account1).precompute(idx, await account1.getAddress());
@@ -159,7 +157,7 @@ describe('KetherNFT', function() {
     ).to.be.revertedWith("ERC721URIStorage: URI query for nonexistent token")
   });
 
-  it("verify precompute", async function() {
+  it("should generate correct precompute address and salt", async function() {
     const idx = 42;
     const account = accounts.account1;
 

--- a/test/kethernft.js
+++ b/test/kethernft.js
@@ -10,31 +10,35 @@ describe('KetherNFT', function() {
   let KetherHomepage, KetherNFT, Wrapper;
   let accounts, KH, KNFT;
 
-  before(async() => {
+  beforeEach(async() => {
     // NOTE: We're using V2 here because it's ported to newer solidity so we can debug more easily. It should also work with V1.
     KetherHomepage = await ethers.getContractFactory("KetherHomepageV2");
     KetherNFT = await ethers.getContractFactory("KetherNFT");
     Wrapper = await ethers.getContractFactory("Wrapper");
 
 
-    const [owner, withdrawWallet, metadataSigner, account1, account2] = await ethers.getSigners();
-    accounts = {owner, withdrawWallet, metadataSigner, account1, account2};
+    const [owner, withdrawWallet, metadataSigner, account1, account2, account3] = await ethers.getSigners();
+    accounts = {owner, withdrawWallet, metadataSigner, account1, account2, account3};
 
     KH = await KetherHomepage.deploy(await owner.getAddress(), await withdrawWallet.getAddress());
     KNFT = await KetherNFT.deploy(KH.address, await metadataSigner.getAddress());
   });
 
-  it("wrap ad with KetherNFT", async function() {
-    const {owner, withdrawWallet, metadataSigner, account1, account2} = accounts;
-
-    // Buy an ad
-    const txn = await KH.connect(account1).buy(0, 0, 10, 10, { value: oneHundredCellPrice });
+  const buyAd = async function(account, x=0, y=0, width=10, height=10, link="link", image="image", title="title", NSFW=false, value=oneHundredCellPrice) {
+    const txn = await KH.connect(account).buy(x, y, width, height, { value: value });
     const receipt = await txn.wait();
     const event = receipt.events.pop();
     const [idx] = event.args;
-    expect(idx).to.equal(0);
+    await KH.connect(account).publish(idx, link, image, title, false);
+    return idx;
+  }
 
-    await KH.connect(account1).publish(idx, "link", "image", "title", false);
+  it("wrap ad with KetherNFT", async function() {
+    const {account1} = accounts;
+
+    // Buy an ad
+    const idx = await buyAd(account1);
+    expect(idx).to.equal(0);
 
     // TODO: Test wrapping to non-owner
     // TODO: Test wrapping by non-owner
@@ -48,9 +52,9 @@ describe('KetherNFT', function() {
     await KNFT.connect(account1).wrap(idx, await account1.getAddress());
 
     // Confirm owner can't publish directly anymore
-    expect(
+    await expect(
       KH.connect(account1).publish(idx, "foo", "bar", "baaz", false)
-    ).to.reverted;
+    ).to.be.reverted;
 
     {
       const [addr,,,,,link,image,title] = await KH.ads(idx);
@@ -59,6 +63,59 @@ describe('KetherNFT', function() {
       expect(image).to.equal("image");
       expect(title).to.equal("title");
     }
+
+    // Confirm NFT owner can publish through the NFT
+    await KNFT.connect(account1).publish(idx, "foo2", "bar2", "baaz2", false);
+
+    {
+      const [addr,,,,,link,image,title] = await KH.ads(idx);
+      expect(addr).to.equal(KNFT.address);
+      expect(link).to.equal("foo2");
+      expect(image).to.equal("bar2");
+      expect(title).to.equal("baaz2");
+    }
+
+  });
+
+  it('wrap to non-owner', async function() {
+    const {account1, account2, account3} = accounts;
+    const idx = await buyAd(account1);
+    {
+      const otherIdx = await buyAd(account2, x=20, y=20);
+      expect(otherIdx).to.not.equal(idx);
+    }
+
+    // Generate precommit to wrap idx (owned by account1) to ownership of account2.
+    // Note that account2 can generate this precommit, as in this case.
+    const [salt, precomputeAddress] = await KNFT.connect(account2).precompute(idx, await account2.getAddress());
+
+    // Non-owner cannot change the ad ownership to precomputed address.
+    await expect(
+      KH.connect(account2).setAdOwner(idx, precomputeAddress)
+    ).to.be.reverted;
+
+    // Non-owner cannot wrap, either
+    await expect(
+      KNFT.connect(account2).wrap(idx, await account2.getAddress())
+    ).to.be.revertedWith("KetherNFT: owner needs to be the correct precommitted address");
+
+    // Same precomputed transaction is fine for the owner to run (precommit wrap to account2)
+    await KH.connect(account1).setAdOwner(idx, precomputeAddress);
+
+    // Rando can't wrap to themselves
+    await expect(
+      KNFT.connect(account3).wrap(idx, await account3.getAddress())
+    ).to.be.revertedWith("KetherNFT: owner needs to be the correct precommitted address");
+
+    // Rando can't wrap to owner (since the precommit is for account2)
+    await expect(
+      KNFT.connect(account3).wrap(idx, await account1.getAddress())
+    ).to.be.revertedWith("KetherNFT: owner needs to be the correct precommitted address");
+
+    // Rando *can* wrap to the precommitted account2
+    // FIXME: Is this desirable? It allows non-owner to pay for the wrap, which is nice.
+    await KNFT.connect(account3).wrap(idx, await account2.getAddress())
+
   });
 
   it("verify precompute", async function() {
@@ -93,7 +150,6 @@ describe('KetherNFT', function() {
       const expected = ethers.utils.getCreate2Address(KNFT.address, salt, ethers.utils.keccak256(bytecode));
       expect(precomputeAddress).to.equal(expected);
     }
-
   });
 
 });


### PR DESCRIPTION
This PR adds a KetherNFT contract for converting KetherHomepage ad units into ERC721-compatible NFTs that retain all the same control properties of ad units.

- [x] Write tests to verify that it works
- [x] Resolve all the TODOs and FIXMEs
- [x] Deploy on Rinkeby: Deployed at https://rinkeby.etherscan.io/address/0x6b69b05a5478a2390493765b496f70a52fe7b816

Closes #48 