### PR TITLE
Ssr

### DIFF
--- a/components/App.vue
+++ b/components/App.vue
@@ -138,7 +138,7 @@ export default {
   },
   methods: {
     async connectEthereum() {
-      if (window.ethereum) {
+      if (process.client && window.ethereum) {
         // Using MetaMask or equivalent
         this.provider = new ethers.providers.Web3Provider(window.ethereum, "any");
         this.activeNetwork = (await this.provider.getNetwork()).name;

--- a/components/App.vue
+++ b/components/App.vue
@@ -120,7 +120,6 @@ const defaultNetwork = "homestead";
 import Dropdown from "./Dropdown.vue";
 import Homepage from "./Homepage.vue";
 
-
 export default {
   name: "app",
   data() {

--- a/components/App.vue
+++ b/components/App.vue
@@ -71,41 +71,8 @@
 <script>
 import { ethers } from "ethers";
 
-import contractJSON from "../build/contracts/KetherHomepage.json";
-
-const deployConfig = {
-  homestead: {
-    name: "main",
-    contractAddr: "0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
-    web3Fallback:
-      "https://mainnet.infura.io/v3/fa9f29a052924745babfc1d119465148",
-    etherscanLink:
-      "https://etherscan.io/address/0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
-    prerendered: {
-      image:
-        "https://storage.googleapis.com/storage.thousandetherhomepage.com/mainnet.png",
-      data: "https://storage.thousandetherhomepage.com/mainnet.json",
-      loadRemoteImages: true,
-      loadFromWeb3: true,
-    },
-  },
-  rinkeby: {
-    name: "rinkeby",
-    contractAddr: "0xb88404dd8fe4969ef67841250baef7f04f6b1a5e",
-    web3Fallback:
-      "https://rinkeby.infura.io/v3/fa9f29a052924745babfc1d119465148",
-    etherscanLink:
-      "https://rinkeby.etherscan.io/address/0xb88404dd8fe4969ef67841250baef7f04f6b1a5e",
-    prerendered: {
-      image:
-        "https://storage.googleapis.com/storage.thousandetherhomepage.com/rinkeby.png",
-      data: "https://storage.thousandetherhomepage.com/rinkeby.json",
-      loadRemoteImages: true,
-      loadFromWeb3: true,
-    },
-  },
-};
-const defaultNetwork = "homestead";
+import { defaultNetwork, deployConfig } from '~/networkConfig';
+import contractJSON from "~/build/contracts/KetherHomepage.json";
 
 import Dropdown from "./Dropdown.vue";
 import Homepage from "./Homepage.vue";

--- a/components/App.vue
+++ b/components/App.vue
@@ -201,6 +201,8 @@ export default {
       }
       this.contract = contract;
 
+      this.$store.dispatch('loadAds', contract);
+
       // Setup event monitoring:
       this.contract.on('error', function(err) {
         console.error("Contract subscription error:", err);

--- a/components/App.vue
+++ b/components/App.vue
@@ -118,36 +118,6 @@ export default {
             window.location.reload();
           }
         });
-
-        // Setup event monitoring:
-
-        // XXX: Validate that this works
-        this.contract.on(this.contract.filters.Buy(), function(idx, owner, x, y, width, height) {
-        if (err) {
-          // TODO: Surface this in UI?
-          console.log("Buy event monitoring disabled, will need to refresh to see changes.")
-          return;
-        }
-
-        this.$store.commit('addAd', {idx, owner, x, y, width, height});
-
-        const previewAd = this.$store.state.previewAd;
-        if (this.previewLocked && Number(x*10) == previewAd.x && Number(y*10) == previewAd.y) {
-          // Colliding ad purchased
-          this.previewLocked = false;
-          this.$store.commit('clearPreview');
-        }
-      }.bind(this))
-
-      this.contract.on(this.contract.filters.Publish(), function(idx, link, image, title, NSFW, height) {
-        if (err) {
-          // TODO: Surface this in UI?
-          console.log("Publish event monitoring disabled, will need to refresh to see changes.")
-          return;
-        }
-
-        this.$store.commit('addAd', {idx, link, image, title, NSFW});
-      }.bind(this))
       } else {
         // Use an HTTP proxy
         await this.setReadOnlyNetwork(defaultNetwork);

--- a/components/Buy.vue
+++ b/components/Buy.vue
@@ -73,7 +73,7 @@ export default {
       return Math.ceil(height * width * ethPerPixel * 100) / 100;
     },
     async checkAccounts() {
-      if (window.ethereum === undefined) return;
+      if (process.server || window.ethereum === undefined) return;
       // This is instead of window.ethereum.enable which causes a big warning
       //const accounts = (await window.ethereum.send('eth_requestAccounts')).result;
 

--- a/components/ConnectWallet.vue
+++ b/components/ConnectWallet.vue
@@ -16,7 +16,7 @@
 export default {
   methods: {
     async requestAccounts() {
-      if (window.ethereum === undefined) return [];
+      if (process.server || window.ethereum === undefined) return [];
 
       if (window.ethereum.request === undefined) {
         return await window.ethereum.enable();

--- a/components/Homepage.vue
+++ b/components/Homepage.vue
@@ -42,17 +42,6 @@ export default {
       showPublish: false,
     }
   },
-  watch: {
-    contract() {
-      // Changing networks (and thus contract instances) will reload the ads
-      this.$store.dispatch('loadAds', this.contract);
-    }
-  },
-  created() {
-    if (process.client) {
-      this.$store.dispatch('loadAds', this.contract);
-    }
-  },
   components: {
     Publish,
     Offline,

--- a/components/Homepage.vue
+++ b/components/Homepage.vue
@@ -65,7 +65,7 @@ export default {
 
       // TODO: error handling?
       let numAds = await this.contract.getAdsLength();
-      this.$store.commit('setAdsLength', numAds);
+      this.$store.commit('setAdsLength', 37);
       let ads = [...Array(numAds.toNumber()).keys()].map(i => this.contract.ads(i));
       for await (const [i, ad] of ads.entries()) {
         this.$store.commit('addAd', toAd(i, await ad));
@@ -79,7 +79,7 @@ export default {
       this.loadAds();
     }
   },
-  created() {
+  fetch() {
     this.loadAds();
   },
   components: {

--- a/components/Homepage.vue
+++ b/components/Homepage.vue
@@ -15,7 +15,7 @@
 }
 </style>
 
-<template v-if="ready">
+<template>
   <div class="container">
     <AdGrid v-if="$store.state.gridVis" :provider="provider" :contract="contract" :showNSFW="showNSFW" :isReadOnly="isReadOnly" :prerendered="prerendered"></AdGrid>
     <AdList v-else="$store.state.gridVis" ></AdList>
@@ -35,22 +35,6 @@ import AdList from './AdList.vue'
 import Publish from './Publish.vue'
 import Offline from './Offline.vue'
 
-function toAd(i, r) {
-  return {
-    idx: i,
-    owner: r[0].toLowerCase(),
-    x: r[1],
-    y: r[2],
-    width: r[3],
-    height: r[4],
-    link: r[5] || "",
-    image: r[6] || "",
-    title: r[7],
-    NSFW: r[8] || r[9],
-    forcedNSFW: r[9],
-  }
-}
-
 export default {
   props: ["provider", "contract", "isReadOnly", "showNSFW", "prerendered"],
   data() {
@@ -58,29 +42,16 @@ export default {
       showPublish: false,
     }
   },
-  methods: {
-    async loadAds() {
-      this.$store.commit('clearAds');
-      this.$store.commit('initGrid');
-
-      // TODO: error handling?
-      let numAds = await this.contract.getAdsLength();
-      this.$store.commit('setAdsLength', 37);
-      let ads = [...Array(numAds.toNumber()).keys()].map(i => this.contract.ads(i));
-      for await (const [i, ad] of ads.entries()) {
-        this.$store.commit('addAd', toAd(i, await ad));
-      }
-    },
-    // FIXME: Removed loadAdsStatic, replace it using nuxt pregen
-  },
   watch: {
     contract() {
       // Changing networks (and thus contract instances) will reload the ads
-      this.loadAds();
+      this.$store.dispatch('loadAds', this.contract);
     }
   },
-  fetch() {
-    this.loadAds();
+  created() {
+    if (process.client) {
+      this.$store.dispatch('loadAds', this.contract);
+    }
   },
   components: {
     Publish,

--- a/components/Publish.vue
+++ b/components/Publish.vue
@@ -131,7 +131,7 @@ export default {
       });
       const signer = await this.provider.getSigner();
       const signerAddr = await signer.getAddress();
-      if (signerAddr != this.ad.owner) {
+      if (signerAddr.toLowerCase() != this.ad.owner) {
         this.error = 'Incorrect active wallet. Must publish with: ' + this.ad.owner;
         return;
       }

--- a/networkConfig.js
+++ b/networkConfig.js
@@ -1,0 +1,33 @@
+export const deployConfig = {
+    homestead: {
+        name: "main",
+        contractAddr: "0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
+        web3Fallback:
+            "https://mainnet.infura.io/v3/fa9f29a052924745babfc1d119465148",
+        etherscanLink:
+            "https://etherscan.io/address/0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
+        prerendered: {
+            image:
+                "https://storage.googleapis.com/storage.thousandetherhomepage.com/mainnet.png",
+            data: "https://storage.thousandetherhomepage.com/mainnet.json",
+            loadRemoteImages: true,
+            loadFromWeb3: true,
+        },
+    },
+    rinkeby: {
+        name: "rinkeby",
+        contractAddr: "0xb88404dd8fe4969ef67841250baef7f04f6b1a5e",
+        web3Fallback:
+            "https://rinkeby.infura.io/v3/fa9f29a052924745babfc1d119465148",
+        etherscanLink:
+            "https://rinkeby.etherscan.io/address/0xb88404dd8fe4969ef67841250baef7f04f6b1a5e",
+        prerendered: {
+            image:
+                "https://storage.googleapis.com/storage.thousandetherhomepage.com/rinkeby.png",
+            data: "https://storage.thousandetherhomepage.com/rinkeby.json",
+            loadRemoteImages: true,
+            loadFromWeb3: true,
+        },
+    },
+};
+export const defaultNetwork = "homestead";

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -49,6 +49,5 @@ export default {
   build: {
   },
 
-  // Disable SSR while developing
-  ssr: false
+  ssr: true
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -12,6 +12,8 @@
 
 <script>
 // Stub for ga. TODO should we cut this entirely?
-window.ga = function () {};
+if (process.client) {
+  window.ga = function () {};
+}
 export default {}
 </script>

--- a/store/index.js
+++ b/store/index.js
@@ -1,38 +1,7 @@
 import { ethers } from "ethers";
-import contractJSON from "../build/contracts/KetherHomepage.json";
 
-const deployConfig = {
-  homestead: {
-    name: "main",
-    contractAddr: "0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
-    web3Fallback:
-      "https://mainnet.infura.io/v3/fa9f29a052924745babfc1d119465148",
-    etherscanLink:
-      "https://etherscan.io/address/0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
-    prerendered: {
-      image:
-        "https://storage.googleapis.com/storage.thousandetherhomepage.com/mainnet.png",
-      data: "https://storage.thousandetherhomepage.com/mainnet.json",
-      loadRemoteImages: true,
-      loadFromWeb3: true,
-    },
-  },
-  rinkeby: {
-    name: "rinkeby",
-    contractAddr: "0xb88404dd8fe4969ef67841250baef7f04f6b1a5e",
-    web3Fallback:
-      "https://rinkeby.infura.io/v3/fa9f29a052924745babfc1d119465148",
-    etherscanLink:
-      "https://rinkeby.etherscan.io/address/0xb88404dd8fe4969ef67841250baef7f04f6b1a5e",
-    prerendered: {
-      image:
-        "https://storage.googleapis.com/storage.thousandetherhomepage.com/rinkeby.png",
-      data: "https://storage.thousandetherhomepage.com/rinkeby.json",
-      loadRemoteImages: true,
-      loadFromWeb3: true,
-    },
-  },
-};
+import { deployConfig, defaultNetwork } from "~/networkConfig";
+import contractJSON from "~/build/contracts/KetherHomepage.json";
 
 export const state = () => ({
   accounts: {},
@@ -176,7 +145,7 @@ export const actions = {
   async nuxtServerInit({ state, dispatch }) {
     // TODO: make this preload both?
     // TODO: refactor this since it shares code with App.vue
-    const web3Fallback = deployConfig["homestead"].web3Fallback || "http://localhost:8545/";
+    const web3Fallback = deployConfig[defaultNetwork].web3Fallback || "http://localhost:8545/";
     const provider = new ethers.providers.JsonRpcProvider(web3Fallback);
     const activeNetwork = (await provider.getNetwork()).name;
     const networkConfig = deployConfig[activeNetwork];

--- a/store/index.js
+++ b/store/index.js
@@ -180,6 +180,9 @@ export const actions = {
   },
 
   async loadAds({ commit }, contract) {
+    // TODO:
+    // if we clear on every load we will refresh all the ads when client side rendering
+    // we need to clear only when we change networks
     commit('clearAds', contract);
     commit('initGrid', contract);
 

--- a/store/index.js
+++ b/store/index.js
@@ -72,7 +72,9 @@ export const mutations = {
     state.ads.length = len;
   },
   addAd(state, ad) {
-    ad.owner = normalizeAddr(ad.owner);
+    if (ad.owner !== undefined) {
+      ad.owner = normalizeAddr(ad.owner);
+    }
 
     if (ad.idx > state.ads.length) {
       state.ads.length = ad.idx;


### PR DESCRIPTION
This is *almost* there! The generated HTML has <img> tags for all the ads on mainnet.

One frustrating thing is that nuxt tries to serialize props and store that it passes from the server render to client, and fails when trying to serialize the ethers objects. So I keep the contract and provider null in server rendering and only populate it on the client. This means there's two ways were interacting with ethereum - in App.vue and in the store (where we pre-populate the ads based on a static call to the infura API). I'd like to refactor this duplication.

What's left
- [x] Remove code duplication (see above)
- [x] The client side render calls `clearAds` as part of it's loading them. We need to only clear the ads when we switch networks, otherwise don't clear them. This will correctly update the ads in place if new ones were bought since the client-side render
- [ ] Do we want to pre-render rinkeby as well? `nuxtServerInit` is called on every dynamic route -- so we can make this happen by making the network part of the route (and redirecting accordingly if you're opening with metamask)
- [ ] I got rid of the `ready` prop and the v-ifs to make the SSR and the client generate the same DOM tree. We may want to add back an indicator that you're waiting for app to sync with your provider.  - decided to not prioritize this
- [ ] I'll get this very verbose ad sometimes `missing response (requestBody="{"method":"eth_call","params":[{"to":"0xb5fe93ccfec708145d6278b0c71ce60aa75ef925","data":"0x11a7a4c00000000000000000000000000000000000000000000000000000000000000083"},"latest"],"id":178,"jsonrpc":"2.0"}", requestMethod="POST", serverError={"errno":-3008,"code":"ENOTFOUND","syscall":"getaddrinfo","hostname":"mainnet.infura.io"}, url="https://mainnet.infura.io/v3/fa9f29a052924745babfc1d119465148", code=SERVER_ERROR, version=web/5.1.0)` - we should handle it better, esp since we're doing a pre-render anyway - https://github.com/thousandetherhomepage/ketherhomepage/issues/58