### PR TITLE
components/Ad.vue: Broken images render as solid color placeholders

### DIFF
--- a/components/Ad.vue
+++ b/components/Ad.vue
@@ -1,9 +1,12 @@
 <template>
   <a :href="link" target="_blank">
-    <div v-if="skipImage" :style="style" :title="title" :class="{ nsfwAd: !shown }" />
-    <img v-else :src="image" :style="style" :title="title" :class="{ nsfwAd: !shown }" @error="placeholder"/>
+    <div v-if="skipImage" :style="style" :title="title" :class="classMap"></div>
+    <img v-else :src="image" :style="style" :title="title" :class="classMap" @error="placeholder"/>
   </a>
 </template>
+
+<style lang="scss">
+</style>
 
 <script>
 function gatewayURL(url) {
@@ -16,7 +19,7 @@ function gatewayURL(url) {
   return url;
 }
 
-function adStyle(ad) {
+function adStyle(ad, blank) {
   if (!ad.width) {
     return {
       "display": "none",
@@ -28,8 +31,10 @@ function adStyle(ad) {
     "width": ad.width * 10 + "px",
     "height": ad.height * 10 + "px",
   }
-  if (!ad.image) {
-    s["background"] = "rgba(255, 255, 255, 0.5)";
+  if (blank || !ad.image) {
+    s["background"] = '#' + ad.owner.slice(-6) + 'cc';
+  } else {
+    s["background"] = '#fff';
   }
   return s;
 }
@@ -47,6 +52,11 @@ function blacklist(link) {
 
 export default {
   props: ["ad", "showNSFW", "skipImage"],
+  data: () => {
+    return {
+      blank: false,
+    };
+  },
   computed: {
     shown() {
       return !this.ad.NSFW || this.showNSFW;
@@ -61,18 +71,22 @@ export default {
       return this.ad.title;
     },
     image() {
-      if (!this.shown) return "";
+      if (!this.shown || this.blank) return "";
       return gatewayURL(this.ad.image);
     },
     style() {
-      return adStyle(this.ad);
+      return adStyle(this.ad, this.blank);
+    },
+    classMap() {
+      return {
+        "nsfwAd": !this.shown,
+        "blank": this.blank,
+      };
     },
   },
   methods: {
     placeholder(el) {
-      const color = this.ad.owner.slice(-6);
-      const svg = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#'+ color +'" /></svg>';
-      el.target.src = 'data:image/svg+xml;base64,' + btoa(svg);
+      this.blank = true;
     },
   },
 }

--- a/components/Ad.vue
+++ b/components/Ad.vue
@@ -1,7 +1,7 @@
 <template>
   <a :href="link" target="_blank">
     <div v-if="skipImage" :style="style" :title="title" :class="{ nsfwAd: !shown }" />
-    <img v-else :src="image" :style="style" :title="title" :class="{ nsfwAd: !shown }" />
+    <img v-else :src="image" :style="style" :title="title" :class="{ nsfwAd: !shown }" @error="placeholder"/>
   </a>
 </template>
 
@@ -66,6 +66,13 @@ export default {
     },
     style() {
       return adStyle(this.ad);
+    },
+  },
+  methods: {
+    placeholder(el) {
+      const color = this.ad.owner.slice(-6);
+      const svg = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#'+ color +'" /></svg>';
+      el.target.src = 'data:image/svg+xml;base64,' + btoa(svg);
     },
   },
 }

--- a/components/AdGrid.vue
+++ b/components/AdGrid.vue
@@ -1,5 +1,15 @@
 <style lang="scss">
 .adGrid {
+  /* Checkerboard: */
+  background-image: /* tint image */
+    linear-gradient(to right, rgba(255,255,255, 0.97), rgba(255,255,255, 0.97)),
+    /* checkered effect */
+    linear-gradient(to right, black 50%, white 50%),
+    linear-gradient(to bottom, black 50%, white 50%);
+  background-blend-mode: normal, difference, normal;
+  background-size: 20px 20px;
+  /***/
+
   img, .nsfwAd, a div {
     position: absolute;
     display: block;
@@ -7,6 +17,11 @@
     font-size: 11px;
     color: rgba(0, 0, 0, 0.7);
     white-space: nowrap;
+  }
+
+  .blank {
+    outline: 2px solid rgba(0,0,0,0.1);
+    outline-offset: -2px;
   }
 
   .nsfwAd {

--- a/static/placeholder.svg
+++ b/static/placeholder.svg
@@ -1,0 +1,1 @@
+<svg width="100%" height="100%"></svg>


### PR DESCRIPTION
Fixes #38 

Mainnet:
![image](https://user-images.githubusercontent.com/6292/119412810-7c488b00-bcba-11eb-86c3-8ac7943d513f.png)

Rinkeby:
![image](https://user-images.githubusercontent.com/6292/119412841-8a96a700-bcba-11eb-9d1d-0aa79045b792.png)

One downside is the title/alt tags don't show through the broken image, but we could tweak that by making it part of the svg.

Also we could do this with css instead of svg, not sure which would be more flexible/performant.
