### PR TITLE
KetherView / Publish proxy / Wrap/Unwap

### DIFF
--- a/components/App.vue
+++ b/components/App.vue
@@ -150,7 +150,7 @@ export default {
     },
     async setReadOnlyNetwork(network) {
       const web3Fallback = deployConfig[network].web3Fallback || "http://localhost:8545/";
-      this.provider = new ethers.providers.JsonRpcProvider(web3Fallback);
+      this.provider = new ethers.providers.StaticJsonRpcProvider(web3Fallback);
       this.activeNetwork = (await this.provider.getNetwork()).name;
       this.networkConfig = deployConfig[this.activeNetwork];
       const contract = new ethers.Contract(this.networkConfig.contractAddr, contractJSON.abi, this.provider);

--- a/components/App.vue
+++ b/components/App.vue
@@ -6,6 +6,7 @@
     <Homepage
       :provider="provider"
       :contract="contract"
+      :ketherNFT="ketherNFT"
       :isReadOnly="isReadOnly"
       :showNSFW="showNSFW"
       :prerendered="prerendered"
@@ -19,7 +20,7 @@
     <div v-else>Active Account: <strong>{{$store.state.activeAccount}}</strong></div>
 
     <div class="info">
-      <p>✅ Loaded {{$store.state.ads.length}} ads as of block {{$store.state.loadedBlockNumber}} ({{timeSinceLoaded}})</p>
+      <p>✅ Loaded {{$store.getters.numAds}} ads ({{$store.getters.numWrapped}} are wrapped as NFTs!) as of block {{$store.state.loadedBlockNumber}} ({{timeSinceLoaded}})</p>
 
       <p>
         Ads displayed above are loaded directly from the Ethereum Blockchain.
@@ -95,6 +96,7 @@ export default {
       selecting: false,
       provider: null,
       contract: null,
+      ketherNFT: null,
       isReadOnly: false,
       showNSFW: false,
       prerendered: null,
@@ -162,6 +164,7 @@ export default {
         this.contract.removeAllListeners();
       }
       this.contract = contract;
+      this.ketherNFT = ketherNFT;
       this.contract.on('error', function(err) {
         console.error("Contract subscription error:", err);
       });
@@ -190,6 +193,8 @@ export default {
         this.$store.commit('addAd', {idx: idx.toNumber(), link, image, title, NSFW});
         console.log("Publish event processed.");
       }.bind(this));
+
+      // TODO we need to subscribe to either SetAdOwner or some NFT events in order to update when wrapping/unwrapping
     },
   },
   async created() {

--- a/components/BuyButton.vue
+++ b/components/BuyButton.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="sold">
-    {{$store.state.adsPixels}} pixels sold <button v-on:click="$store.commit('updatePreview', {x, y})" v-if="!$store.state.previewAd">Buy Pixels</button>
+    {{$store.state.adsPixels}} pixels sold
+    <a target="_blank" href="https://opensea.io/collection/thousand-ether-homepage" v-if="this.$store.getters.isSoldOut" disabled>Available on OpenSea</a>
+    <button v-on:click="$store.commit('updatePreview', {x, y})" v-else-if="!$store.state.previewAd">Buy Pixels</button>
   </div>
 </template>
 
@@ -14,10 +16,17 @@
   color: white;
   font-weight: bold;
 
-    button {
-      margin-left: 5px;
-    }
+  button {
+    margin-left: 5px;
   }
+
+  a {
+    background: rgba(255,255,255,0.9);
+    border: 1px solid rgba(0,0,0,0.5);
+    padding: 2px 0.5em;
+    border-radius: 3px;
+  }
+}
 </style>
 
 <script>

--- a/components/Homepage.vue
+++ b/components/Homepage.vue
@@ -21,7 +21,7 @@
     <LazyAdList v-else />
 
     <div class="edit" v-if="$store.getters.numOwned > 0">
-      {{$store.getters.numOwned}} ads owned by you, {{$store.getters.numOwnedWrapped}} are wrapped as NFTs. <button v-on:click="showPublish = true" v-if="!showPublish">Edit Ads</button>
+      {{$store.getters.numOwned}} ads owned by you, {{$store.getters.numOwnedWrapped}} are wrapped as NFTs. <button v-on:click="showPublish = true" v-if="!showPublish">Edit and Wrap Ads</button>
     </div>
     <LazyPublish v-if="showPublish" :provider="provider" :contract="contract" :ketherNFT="ketherNFT" :showNSFW="showNSFW" />
   </div>

--- a/components/Homepage.vue
+++ b/components/Homepage.vue
@@ -21,7 +21,7 @@
     <LazyAdList v-else />
 
     <div class="edit" v-if="$store.getters.numOwned > 0">
-      {{$store.getters.numOwned}} ads owned by you, {{$store.getters.numOwnedWrapped}} are wrapped as NFTs. <button v-on:click="showPublish = true" v-if="!showPublish">Edit and Wrap Ads</button>
+      {{$store.getters.numOwned}} ads owned by you, {{$store.getters.numOwnedWrapped}} wrapped as NFT. <button v-on:click="showPublish = true" v-if="!showPublish">Edit and Wrap Ads</button>
     </div>
     <LazyPublish v-if="showPublish" :provider="provider" :contract="contract" :ketherNFT="ketherNFT" :showNSFW="showNSFW" />
   </div>

--- a/components/Homepage.vue
+++ b/components/Homepage.vue
@@ -21,9 +21,9 @@
     <LazyAdList v-else />
 
     <div class="edit" v-if="$store.getters.numOwned > 0">
-      {{$store.getters.numOwned}} ads owned by you. <button v-on:click="showPublish = true" v-if="!showPublish">Edit Ads</button>
+      {{$store.getters.numOwned}} ads owned by you. ({{$store.getters.numOwnedWrapped}} are wrapped as NFTs)<button v-on:click="showPublish = true" v-if="!showPublish">Edit Ads</button>
     </div>
-    <LazyPublish v-if="showPublish" :provider="provider" :contract="contract" :showNSFW="showNSFW" />
+    <LazyPublish v-if="showPublish" :provider="provider" :contract="contract" :ketherNFT="ketherNFT" :showNSFW="showNSFW" />
   </div>
 </template>
 
@@ -34,7 +34,7 @@ import Publish from './Publish.vue'
 import Offline from './Offline.vue'
 
 export default {
-  props: ["provider", "contract", "isReadOnly", "showNSFW", "prerendered"],
+  props: ["provider", "contract", "ketherNFT", "isReadOnly", "showNSFW", "prerendered"],
   data() {
     return {
       showPublish: false,

--- a/components/Homepage.vue
+++ b/components/Homepage.vue
@@ -21,7 +21,7 @@
     <LazyAdList v-else />
 
     <div class="edit" v-if="$store.getters.numOwned > 0">
-      {{$store.getters.numOwned}} ads owned by you. ({{$store.getters.numOwnedWrapped}} are wrapped as NFTs)<button v-on:click="showPublish = true" v-if="!showPublish">Edit Ads</button>
+      {{$store.getters.numOwned}} ads owned by you, {{$store.getters.numOwnedWrapped}} are wrapped as NFTs. <button v-on:click="showPublish = true" v-if="!showPublish">Edit Ads</button>
     </div>
     <LazyPublish v-if="showPublish" :provider="provider" :contract="contract" :ketherNFT="ketherNFT" :showNSFW="showNSFW" />
   </div>

--- a/components/Publish.vue
+++ b/components/Publish.vue
@@ -186,12 +186,13 @@ export default {
       }
       try {
         const { predictedAddress } = (await this.ketherNFT.precompute(this.ad.idx, signerAddr));
-        // TODO this doesn't acutally work
-        // We need to group these somehow but send one after the first transaction is mined?
-        // Also we need to be able to rescue if only the first part worked (e.g. if you have an ad at your predicted address)
+
+        // TODO we need to be able to rescue if only the first part worked (e.g. if you have an ad at your predicted address)
         // Right now it won't show up after a refresh in the UI because it belongs to a precomputed address and hasn't been minted yet..
-        await this.contract.connect(signer).setAdOwner(this.ad.idx, predictedAddress)
-        await this.ketherNFT.connect(signer).wrap(this.ad.idx, signerAddr)
+        await (await this.contract.connect(signer).setAdOwner(this.ad.idx, predictedAddress)).wait();
+        await this.ketherNFT.connect(signer).wrap(this.ad.idx, signerAddr);
+        //TODO trigger reload here?
+        //TODO throbber or message that transaction has been submitted
       } catch(err) {
          this.error = err;
       } finally {

--- a/components/Publish.vue
+++ b/components/Publish.vue
@@ -15,7 +15,7 @@ input {
   width: 200px;
 }
 
-.editAd {
+.editAd, .wrapAd {
   border-left: 10px solid #eee;
   padding-left: 10px;
 
@@ -40,20 +40,23 @@ input {
     display: block;
     border-width: 2px;
   }
+  .mini-adGrid {
+    padding: 10px;
+    background: #ddd;
+    margin-bottom: 1em;
+  }
+}
 
-  .button-group {
+.wrapAd {
+  label {
     display: flex;
+    line-height: 2em;
 
     button {
       margin-right: 0.25em;
     }
   }
 
-  .mini-adGrid {
-    padding: 10px;
-    background: #ddd;
-    margin-bottom: 1em;
-  }
 }
 </style>
 
@@ -66,7 +69,23 @@ input {
         #{{ad.idx}} ({{ad.wrapped ? "NFT" : "Not wrapped"}})- {{ad.width*10}}x{{ad.height*10}}px at ({{ad.x}}, {{ad.y}}): {{ad.title}} - {{ ad.link || "(no link)" }}
         </option>
       </select>
+
+      <div v-if="ad" class="wrapAd">
+        <h3>NFT</h3>
+        <p v-if="ad.wrapped">
+          Ad is wrapped to NFT. 
+          <button type="button" v-on:click="unwrap">Unwrap</button>
+        </p>
+        <p v-else>
+          <label>
+            <button type="button" v-on:click="wrap">Wrap to NFT</button> 
+            <span>(Queue up 2 on-chain transactions)</span>
+          </label>
+        </p>
+      </div>
+
       <div v-if="ad" class="editAd">
+        <h3>Publish Changes</h3>
         <p>
           What do you want your ad to look like? Some rules:
         </p>
@@ -105,10 +124,8 @@ input {
             <Ad :showNSFW="showNSFW" :ad="ad" class="previewAd"></Ad>
           </div>
         </div>
-        <div class="button-group">
+        <div>
           <button type="submit">Publish Changes</button>
-          <button type="button" v-on:click="wrap" v-if="!ad.wrapped">Wrap</button>
-          <button type="button" v-on:click="unwrap" v-if="ad.wrapped">Unwrap</button>
         </div>
         <small>
           It can take between 10 seconds to a few minutes for your published ad

--- a/components/Wrap.vue
+++ b/components/Wrap.vue
@@ -64,8 +64,11 @@ input {
   <div>
     <form v-on:submit.prevent class="wrapAd">
       <h3>NFT</h3>
+      <p v-if="wrapInProgress">
+        ⏳<strong>Wrapping transaction in progress.</strong> Check your wallet for queued transactions, there should be 2 total.
+      </p>
       <p v-if="ad.wrapped">
-      Ad is wrapped to NFT. 
+      Ad is wrapped to NFT.
       <button type="button" v-on:click="unwrap">Unwrap #{{ad.idx}} to Legacy Contract</button>
       </p>
       <p v-else>
@@ -102,6 +105,7 @@ export default {
         const { predictedAddress } = (await this.ketherNFT.precompute(this.ad.idx, signerAddr));
 
         // TODO we need to be able to rescue if only the first part worked (e.g. if you have an ad at your predicted address)
+        this.wrapInProgress = true;
         // Right now it won't show up after a refresh in the UI because it belongs to a precomputed address and hasn't been minted yet..
         await (await this.contract.connect(signer).setAdOwner(this.ad.idx, predictedAddress)).wait();
         await this.ketherNFT.connect(signer).wrap(this.ad.idx, signerAddr);
@@ -109,8 +113,10 @@ export default {
         //TODO throbber or message that transaction has been submitted
       } catch(err) {
          this.error = err;
+        this.wrapInProgress = false;
       } finally {
         this.ad = false;
+        this.wrapInProgress = false;
       }
     },
     async unwrap() {

--- a/components/Wrap.vue
+++ b/components/Wrap.vue
@@ -1,0 +1,133 @@
+<style lang="scss">
+form {
+  margin-bottom: 2em;
+  width: 600px;
+}
+label {
+  display: block;
+  margin-bottom: 0.5em;
+  span {
+    display: inline-block;
+    min-width: 6em;
+  }
+}
+input {
+  width: 200px;
+}
+
+.wrapAd {
+  border-left: 10px solid #eee;
+  padding-left: 10px;
+
+  .previewAd img {
+    display: block;
+    overflow: hidden;
+    font-size: 11px;
+    color: rgba(0, 0, 0, 0.7);
+    white-space: nowrap;
+  }
+
+  small {
+    color: #966;
+    margin: 0.5em;
+    display: inline-block;
+  }
+
+  button {
+    font-size: 1em;
+    padding: 5px;
+    background: #fff8db;
+    display: block;
+    border-width: 2px;
+  }
+  .mini-adGrid {
+    padding: 10px;
+    background: #ddd;
+    margin-bottom: 1em;
+  }
+}
+
+.wrapAd {
+  label {
+    display: flex;
+    line-height: 2em;
+
+    button {
+      margin-right: 0.25em;
+    }
+  }
+
+}
+</style>
+
+<template>
+  <div>
+    <form v-on:submit.prevent class="wrapAd">
+      <h3>NFT</h3>
+      <p v-if="ad.wrapped">
+      Ad is wrapped to NFT. 
+      <button type="button" v-on:click="unwrap">Unwrap #{{ad.idx}} to Legacy Contract</button>
+      </p>
+      <p v-else>
+      <label>
+        <button type="button" v-on:click="wrap">Wrap #{{ad.idx}} to NFT</button> 
+        <span>(Queue up 2 on-chain transactions)</span>
+      </label>
+      </p>
+    </form>
+    <p v-if="error" class="error">
+      {{ error }}
+    </p>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ["provider", "contract", "ketherNFT", "ad"],
+  data() {
+    return {
+      error: null,
+      wrapInProgress: false,
+    }
+  },
+  methods: {
+    async wrap() {
+      const signer = await this.provider.getSigner();
+      const signerAddr = await signer.getAddress();
+      if (signerAddr.toLowerCase() != this.ad.owner) {
+        this.error = 'Incorrect active wallet. Must publish with: ' + this.ad.owner;
+        return;
+      }
+      try {
+        const { predictedAddress } = (await this.ketherNFT.precompute(this.ad.idx, signerAddr));
+
+        // TODO we need to be able to rescue if only the first part worked (e.g. if you have an ad at your predicted address)
+        // Right now it won't show up after a refresh in the UI because it belongs to a precomputed address and hasn't been minted yet..
+        await (await this.contract.connect(signer).setAdOwner(this.ad.idx, predictedAddress)).wait();
+        await this.ketherNFT.connect(signer).wrap(this.ad.idx, signerAddr);
+        //TODO trigger reload here?
+        //TODO throbber or message that transaction has been submitted
+      } catch(err) {
+         this.error = err;
+      } finally {
+        this.ad = false;
+      }
+    },
+    async unwrap() {
+      const signer = await this.provider.getSigner();
+      const signerAddr = await signer.getAddress();
+      if (signerAddr.toLowerCase() != this.ad.owner) {
+        this.error = 'Incorrect active wallet. Must publish with: ' + this.ad.owner;
+        return;
+      }
+      try {
+        await this.ketherNFT.connect(signer).unwrap(this.ad.idx, signerAddr)
+      } catch(err) {
+         this.error = err;
+      } finally {
+        this.ad = false;
+      }
+    }
+  },
+}
+</script>

--- a/contracts/KetherView.sol
+++ b/contracts/KetherView.sol
@@ -1,29 +1,39 @@
 import "./IKetherHomepage.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
-contract KetherView {
+library KetherView {
+  struct AdView {
+    address owner;
+    uint x;
+    uint y;
+    uint width;
+    uint height;
+    string link;
+    string image;
+    string title;
+    bool NSFW;
+    bool forceNSFW;
+    bool wrapped;
+  }
   /// allAds is a helper view designed to be called from frontends that want to
   /// display all of the ads with their correct NFT owners.
-  function allAds(IKetherHomepage instance) external view returns (IKetherHomepage.Ad[] memory) {
+  function allAds(address _instanceAddress, address _nftAddress) external view returns (AdView[] memory) {
     // FIXME: Does this actually enumerate all of the ads, or do we need to paginate?
-    uint len = instance.getAdsLength();
-    IKetherHomepage.Ad[] memory ads_ = new IKetherHomepage.Ad[](len);
+    AdView[] memory ads_ = new AdView[](IKetherHomepage(_instanceAddress).getAdsLength());
 
-    for (uint idx=0; idx<len; idx++) {
-      (address owner, uint x, uint y, uint width, uint height, string memory link, string memory image, string memory title, bool NSFW, bool forceNSFW) = instance.ads(idx);
-
-      /* XXX: Fix this
+    for (uint idx=0; idx<ads_.length; idx++) {
+      (address owner, uint x, uint y, uint width, uint height, string memory link, string memory image, string memory title, bool NSFW, bool forceNSFW) = IKetherHomepage(_instanceAddress).ads(idx);
+      bool wrapped = false;
 
       // Is it an NFT already?
-      if (_exists(idx)) {
+      if (owner == _nftAddress) {
         // Override owner to be the NFT owner
-        owner = ownerOf(idx);
+        owner = IERC721(_nftAddress).ownerOf(idx);
+        wrapped = true;
       }
 
-      */
-
-      ads_[idx] = IKetherHomepage.Ad(owner, x, y, width, height, link, image, title, NSFW, forceNSFW);
+      ads_[idx] = AdView(owner, x, y, width, height, link, image, title, NSFW, forceNSFW, wrapped);
     }
     return ads_;
   }
-
 }

--- a/contracts/KetherView.sol
+++ b/contracts/KetherView.sol
@@ -1,5 +1,14 @@
-import "./IKetherHomepage.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.8.4;
+
+interface IKetherHomepage {
+  function ads(uint _idx) external view returns (address,uint,uint,uint,uint,string memory,string memory,string memory,bool,bool);
+  function getAdsLength() view external returns (uint);
+}
+
+interface IERC721 {
+  function ownerOf(uint256) external view returns (address);
+}
 
 library KetherView {
   struct AdView {

--- a/contracts/KetherView.sol
+++ b/contracts/KetherView.sol
@@ -28,7 +28,9 @@ library KetherView {
   /// allAds is a helper view designed to be called from frontends that want to
   /// display all of the ads with their correct NFT owners.
   function allAds(address _instanceAddress, address _nftAddress, uint _offset, uint _limit) external view returns (AdView[] memory) {
-    uint len = IKetherHomepage(_instanceAddress).getAdsLength();
+    // TODO: this errors out with `Error: Transaction reverted: library was called directly` if _offset is > length.
+    // should we add a better error?
+    uint len = IKetherHomepage(_instanceAddress).getAdsLength() - _offset;
     if (_limit < len) {
       len = _limit;
     }

--- a/networkConfig.js
+++ b/networkConfig.js
@@ -18,6 +18,7 @@ export const deployConfig = {
             loadRemoteImages: true,
             loadFromWeb3: true,
         },
+        nftView: "https://opensea.io/assets/",
     },
     rinkeby: {
         name: "rinkeby",
@@ -32,6 +33,7 @@ export const deployConfig = {
             loadRemoteImages: true,
             loadFromWeb3: true,
         },
+        nftView: "https://testnets.opensea.io/assets/",
     },
 };
 deployConfig.mainnet = deployConfig.homestead;

--- a/networkConfig.js
+++ b/networkConfig.js
@@ -8,7 +8,7 @@ export const deployConfig = {
     homestead: {
         name: "main",
         contractAddr: "0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
-        ketherNFTAddr: "0x7bb952ab78b28a62b1525aca54a71e7aa6177645", // Must be normalized per normalizeAddr (lowercase)
+        ketherNFTAddr: "0x7bb952ab78b28a62b1525aca54a71e7aa6177645",
         ketherViewAddr: "0xa95b4e81a892A74bB5f1fA5F33d8362212a98C99",
         web3Fallback: "https://mainnet.infura.io/v3/fa9f29a052924745babfc1d119465148",
         etherscanLink: "https://etherscan.io/address/0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
@@ -35,7 +35,7 @@ export const deployConfig = {
     },
 };
 deployConfig.mainnet = deployConfig.homestead;
-export const defaultNetwork = "rinkeby";
+export const defaultNetwork = "homestead";
 
 export const loadContracts = (networkConfig, provider) => {
     const contract = new ethers.Contract(networkConfig.contractAddr, contractJSON.abi, provider);

--- a/networkConfig.js
+++ b/networkConfig.js
@@ -1,8 +1,15 @@
+import { ethers } from "ethers";
+
+import contractJSON from "~/artifacts/contracts/KetherHomepage.sol/KetherHomepage.json";
+import ketherNFTJSON from "~/artifacts/contracts/KetherNFT.sol/KetherNFT.json";
+import ketherViewJSON from "~/artifacts/contracts/KetherView.sol/KetherView.json";
+
 export const deployConfig = {
     homestead: {
         name: "main",
         contractAddr: "0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
         ketherNFTAddr: "TODO", // Must be normalized per normalizeAddr (lowercase)
+        ketherViewAddr: "TODO",
         web3Fallback: "https://mainnet.infura.io/v3/fa9f29a052924745babfc1d119465148",
         etherscanLink: "https://etherscan.io/address/0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
         prerendered: {
@@ -15,7 +22,8 @@ export const deployConfig = {
     rinkeby: {
         name: "rinkeby",
         contractAddr: "0xb88404dd8fe4969ef67841250baef7f04f6b1a5e",
-        ketherNFTAddr: "TODO", // Must be normalized per normalizeAddr (lowercase)
+        ketherNFTAddr: "0xb7fcb57a5ce2f50c3203ccda27c05aeadaf2c221",
+        ketherViewAddr: "0x126c76281fb6ee945bef9b92aac5d46eb8bda299",
         web3Fallback: "https://rinkeby.infura.io/v3/fa9f29a052924745babfc1d119465148",
         etherscanLink: "https://rinkeby.etherscan.io/address/0xb88404dd8fe4969ef67841250baef7f04f6b1a5e",
         prerendered: {
@@ -27,4 +35,12 @@ export const deployConfig = {
     },
 };
 deployConfig.mainnet = deployConfig.homestead;
-export const defaultNetwork = "homestead";
+export const defaultNetwork = "rinkeby";
+
+export const loadContracts = (networkConfig, provider) => {
+    const contract = new ethers.Contract(networkConfig.contractAddr, contractJSON.abi, provider);
+    const ketherNFT = new ethers.Contract(networkConfig.ketherNFTAddr, ketherNFTJSON.abi, provider);
+    const ketherView = new ethers.Contract(networkConfig.ketherViewAddr, ketherViewJSON.abi, provider);
+
+    return {contract, ketherNFT, ketherView}
+}

--- a/networkConfig.js
+++ b/networkConfig.js
@@ -9,7 +9,7 @@ export const deployConfig = {
         name: "main",
         contractAddr: "0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
         ketherNFTAddr: "0x7bb952ab78b28a62b1525aca54a71e7aa6177645",
-        ketherViewAddr: "TODO", // "0xa95b4e81a892A74bB5f1fA5F33d8362212a98C99",
+        ketherViewAddr: "0xaC292791A8b398698363F820dd6FbEE6EDF71442",
         web3Fallback: "https://mainnet.infura.io/v3/fa9f29a052924745babfc1d119465148",
         etherscanLink: "https://etherscan.io/address/0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
         prerendered: {

--- a/networkConfig.js
+++ b/networkConfig.js
@@ -9,7 +9,7 @@ export const deployConfig = {
         name: "main",
         contractAddr: "0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
         ketherNFTAddr: "0x7bb952ab78b28a62b1525aca54a71e7aa6177645",
-        ketherViewAddr: "0xa95b4e81a892A74bB5f1fA5F33d8362212a98C99",
+        ketherViewAddr: "TODO", // "0xa95b4e81a892A74bB5f1fA5F33d8362212a98C99",
         web3Fallback: "https://mainnet.infura.io/v3/fa9f29a052924745babfc1d119465148",
         etherscanLink: "https://etherscan.io/address/0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
         prerendered: {
@@ -23,7 +23,7 @@ export const deployConfig = {
         name: "rinkeby",
         contractAddr: "0xb88404dd8fe4969ef67841250baef7f04f6b1a5e",
         ketherNFTAddr: "0xb7fcb57a5ce2f50c3203ccda27c05aeadaf2c221",
-        ketherViewAddr: "0x126c76281fb6ee945bef9b92aac5d46eb8bda299",
+        ketherViewAddr: "0xd58D4ff574140472F9Ae2a90B6028Df822c10109",
         web3Fallback: "https://rinkeby.infura.io/v3/fa9f29a052924745babfc1d119465148",
         etherscanLink: "https://rinkeby.etherscan.io/address/0xb88404dd8fe4969ef67841250baef7f04f6b1a5e",
         prerendered: {

--- a/networkConfig.js
+++ b/networkConfig.js
@@ -8,8 +8,8 @@ export const deployConfig = {
     homestead: {
         name: "main",
         contractAddr: "0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
-        ketherNFTAddr: "TODO", // Must be normalized per normalizeAddr (lowercase)
-        ketherViewAddr: "TODO",
+        ketherNFTAddr: "0x7bb952ab78b28a62b1525aca54a71e7aa6177645", // Must be normalized per normalizeAddr (lowercase)
+        ketherViewAddr: "0xa95b4e81a892A74bB5f1fA5F33d8362212a98C99",
         web3Fallback: "https://mainnet.infura.io/v3/fa9f29a052924745babfc1d119465148",
         etherscanLink: "https://etherscan.io/address/0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
         prerendered: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6630,13 +6630,13 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git",
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
             "ethereumjs-util": "^5.1.1"
           }
         },
         "ethereumjs-abi": {
-          "version": "git+ssh://git@github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
-          "from": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git",
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
             "bn.js": "^4.11.8",
             "ethereumjs-util": "^6.0.0"
@@ -13490,7 +13490,8 @@
         },
         "keccak": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+          "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
           "dev": true,
           "requires": {
             "node-addon-api": "^2.0.0",
@@ -14037,7 +14038,8 @@
         },
         "node-addon-api": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+          "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
           "dev": true
         },
         "node-fetch": {
@@ -14048,7 +14050,8 @@
         },
         "node-gyp-build": {
           "version": "4.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
           "dev": true
         },
         "normalize-url": {
@@ -16478,13 +16481,13 @@
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "dev": true,
               "requires": {
-                "ethereumjs-abi": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git",
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
                 "ethereumjs-util": "^5.1.1"
               }
             },
             "ethereumjs-abi": {
-              "version": "git+ssh://git@github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
-              "from": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git",
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "dev": true,
               "requires": {
                 "bn.js": "^4.11.8",
@@ -24527,13 +24530,13 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git",
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
             "ethereumjs-util": "^5.1.1"
           }
         },
         "ethereumjs-abi": {
-          "version": "git+ssh://git@github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
-          "from": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git",
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
             "bn.js": "^4.11.8",
             "ethereumjs-util": "^6.0.0"

--- a/scripts/deployKetherNFT.js
+++ b/scripts/deployKetherNFT.js
@@ -16,7 +16,7 @@ const deployed = {
     ketherHomepageAddress: "0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
     ketherNFTRendererAddress: "0x228c17030a866CcBf6734fA4262Dee64f0E392be",
     ketherNFTAddress: "0x7bb952AB78b28a62b1525acA54A71E7Aa6177645",
-    ketherViewAddress: "0xa95b4e81a892A74bB5f1fA5F33d8362212a98C99",
+    ketherViewAddress: "0xaC292791A8b398698363F820dd6FbEE6EDF71442",
   },
 };
 

--- a/scripts/deployKetherNFT.js
+++ b/scripts/deployKetherNFT.js
@@ -8,6 +8,7 @@ const deployed = {
     ketherNFTOwnerAddress: "0xbCb061d2feE38DCB6DE7e5D269852B4BDb986Ed6",
     ketherNFTRendererAddress: "0xc767472dddaa5eb84e4dcc237101ae7fd7f2e03c",
     ketherNFTAddress: "0xB7fCb57a5ce2F50C3203ccda27c05AEAdAF2C221",
+    ketherViewAddress: "0x126C76281Fb6ee945BeF9b92aaC5D46eB8bDA299"
   },
   'mainnet': {
     ownerAddress: "0xd534d9f6e61780b824afaa68032a7ec11720ca12",
@@ -50,12 +51,14 @@ async function main() {
   if (account === undefined) {
     throw "Signer account not provided, specify ACCOUNT_PRIVATE_KEY";
   } else if (account.address !== cfg.ketherNFTOwnerAddress) {
-    throw "Did not acquire signer for owner address: " + cfg.ketherNFTOwnerAddress + "; got: " + account.address;
+   // throw "Did not acquire signer for owner address: " + cfg.ketherNFTOwnerAddress + "; got: " + account.address;
   }
   console.log("Starting deploys from address:", account.address);
 
   const KetherNFT = await ethers.getContractFactory("KetherNFT");
   const KetherNFTRender = await ethers.getContractFactory("KetherNFTRender");
+  const KetherView = await ethers.getContractFactory("KetherView");
+
 
   let ketherNFTRendererAddress = cfg["ketherNFTRendererAddress"];
   if (ketherNFTRendererAddress === undefined) {
@@ -84,6 +87,20 @@ async function main() {
   }
 
   console.log(`Verify on Etherscan: npx hardhat verify --network ${network.name} ${ketherNFTAddress} "${KH.address}" "${ketherNFTRendererAddress}"`);
+
+  let ketherViewAddress = cfg["ketherViewAddress"];
+  if (ketherViewAddress === undefined) {
+    const KView = await KetherView.deploy({ maxFeePerGas, maxPriorityFeePerGas });
+    console.log("Deploying KetherView to:", KView.address);
+    ketherViewAddress = KView.address;
+
+    const tx = await KView.deployTransaction.wait();
+    console.log(" -> Mined with", tx.gasUsed.toString(), "gas");
+  } else {
+    console.log("KetherView already deployed");
+  }
+
+  console.log(`Verify on Etherscan: npx hardhat verify --network ${network.name} ${ketherViewAddress}`);
 }
 
 main()

--- a/scripts/deployKetherNFT.js
+++ b/scripts/deployKetherNFT.js
@@ -8,7 +8,7 @@ const deployed = {
     ketherNFTOwnerAddress: "0xbCb061d2feE38DCB6DE7e5D269852B4BDb986Ed6",
     ketherNFTRendererAddress: "0xc767472dddaa5eb84e4dcc237101ae7fd7f2e03c",
     ketherNFTAddress: "0xB7fCb57a5ce2F50C3203ccda27c05AEAdAF2C221",
-    ketherViewAddress: "0x126C76281Fb6ee945BeF9b92aaC5D46eB8bDA299"
+    ketherViewAddress: "0x126C76281Fb6ee945BeF9b92aaC5D46eB8bDA299",
   },
   'mainnet': {
     ownerAddress: "0xd534d9f6e61780b824afaa68032a7ec11720ca12",
@@ -16,6 +16,7 @@ const deployed = {
     ketherHomepageAddress: "0xb5fe93ccfec708145d6278b0c71ce60aa75ef925",
     ketherNFTRendererAddress: "0x228c17030a866CcBf6734fA4262Dee64f0E392be",
     ketherNFTAddress: "0x7bb952AB78b28a62b1525acA54A71E7Aa6177645",
+    ketherViewAddress: "0xa95b4e81a892A74bB5f1fA5F33d8362212a98C99",
   },
 };
 

--- a/store/index.js
+++ b/store/index.js
@@ -203,9 +203,8 @@ export const actions = {
       const limit = 420; // 4 queries to load 1621 ads on mainnet
       const len = await contract.getAdsLength();
       commit('setAdsLength', len);
-      //TODO test off-by-ones
+      //TODO: test off-by-ones
       for (let offset = 0; offset < len; offset+=limit) {
-        // TODO: the structure here contains a `wrapped` bool which we can use to power proxying publish to the nft contract and wrapping/unwrapping.
         ketherView.allAds(contract.address, ketherNFT.address, offset, limit).then((ads) => {
           commit('importAds', ads);
         });

--- a/store/index.js
+++ b/store/index.js
@@ -123,8 +123,14 @@ export const getters = {
   numAds: state => {
     return state.ads.length;
   },
+  numWrapped: state => {
+    return state.ads.filter(ad => ad.wrapped).length;;
+  },
   numOwned: state => {
     return Object.keys(state.ownedAds).length;
+  },
+  numOwnedWrapped: state => {
+    return Object.values(state.ownedAds).filter(ad => ad.wrapped).length;
   },
   numNSFW: state => {
     return state.ads.filter(ad => ad.NSFW).length;
@@ -325,7 +331,10 @@ function eventToAd(state, adEvent) {
   } else if (adEvent.NSFW !== undefined) {
     ad.NSFW = adEvent.NSFW;
   }
-
+  // TODO will this break if we load stuff from events and not KetherView?
+  if (adEvent.wrapped !== undefined) {
+    ad.wrapped = adEvent.wrapped;
+  }
   let existingAd = state.ads[ad.idx];
   if (existingAd !== undefined && existingAd.width !== undefined) {
     // Already counted, update values
@@ -339,6 +348,7 @@ function eventToAd(state, adEvent) {
     title: "",
     NSFW: false,
     forceNSFW: false,
+    wrapped: false,
   }, ad);
 }
 

--- a/store/index.js
+++ b/store/index.js
@@ -143,7 +143,7 @@ export const actions = {
     if (route.name !== 'index') return; // We only want to preload ads for the index route
 
     const web3Fallback = deployConfig[defaultNetwork].web3Fallback || "http://localhost:8545/";
-    const provider = new ethers.providers.JsonRpcProvider(web3Fallback);
+    const provider = new ethers.providers.StaticJsonRpcProvider(web3Fallback);
     const activeNetwork = (await provider.getNetwork()).name;
     const networkConfig = deployConfig[activeNetwork];
     const contract = new ethers.Contract(networkConfig.contractAddr, contractJSON.abi, provider);

--- a/store/index.js
+++ b/store/index.js
@@ -200,7 +200,7 @@ export const actions = {
     const loadFromEvents = true; // Okay to do it always? or should we do: state.loadedBlockNumber > 0
 
     if (loadFromKetherView) {
-      const limit = 325; // 5 queries to load 1621 ads on mainnet. 4 queries works too, but maybe flakey?
+      const limit = 165; // 10 queries to load 1621 ads on mainnet. 4 queries works too, but maybe flakey?
       const len = await contract.getAdsLength();
       commit('setAdsLength', len);
       //TODO: test off-by-ones
@@ -208,6 +208,9 @@ export const actions = {
         ketherView.allAds(contract.address, ketherNFT.address, offset, limit).then((ads) => {
           // Imported concurrently
           commit('importAds', ads);
+        }).catch((err) => {
+          // TODO: Implement retrying
+          window.location.reload(); // lol
         });
       }
     } else if (loadFromEvents) {

--- a/store/index.js
+++ b/store/index.js
@@ -194,11 +194,14 @@ export const actions = {
     const loadFromEvents = true; // Okay to do it always? or should we do: state.loadedBlockNumber > 0
 
     if (loadFromKetherView) {
-      const ads = await ketherView.allAds(contract.address, ketherNFT.address)
-      commit('setAdsLength', ads.length);
-      for (const [i, ad] of ads.entries()) {
+      const limit = 200;
+      const len = await contract.getAdsLength();
+      commit('setAdsLength', len);
+      //TODO test off-by-ones
+      for (let offset = 0; offset < len; offset+=limit) {
+        const ads = await ketherView.allAds(contract.address, ketherNFT.address, offset, limit);
         // TODO: the structure here contains a `wrapped` bool which we can use to power proxying publish to the nft contract and wrapping/unwrapping.
-        commit('addAd', toAd(i, await ad));
+        commit('importAds', ads);
       }
     }
     else if (loadFromEvents) {

--- a/store/index.js
+++ b/store/index.js
@@ -200,12 +200,13 @@ export const actions = {
     const loadFromEvents = true; // Okay to do it always? or should we do: state.loadedBlockNumber > 0
 
     if (loadFromKetherView) {
-      const limit = 420; // 4 queries to load 1621 ads on mainnet
+      const limit = 325; // 5 queries to load 1621 ads on mainnet. 4 queries works too, but maybe flakey?
       const len = await contract.getAdsLength();
       commit('setAdsLength', len);
       //TODO: test off-by-ones
       for (let offset = 0; offset < len; offset+=limit) {
         ketherView.allAds(contract.address, ketherNFT.address, offset, limit).then((ads) => {
+          // Imported concurrently
           commit('importAds', ads);
         });
       }

--- a/store/index.js
+++ b/store/index.js
@@ -222,6 +222,7 @@ export const actions = {
         promises.push(loadAds(offset, limit));
       }
       await Promise.all(promises);
+
     } else if (loadFromEvents) {
       // Skip loading and use event filter instead (does 1 query to eth_logs)
       const eventFilter= [ contract.filters.Buy(), contract.filters.Publish(), contract.filters.SetAdOwner() ];
@@ -295,6 +296,8 @@ function addAdOwned(state, ad) {
 }
 
 function addNFTAd(state, ad) {
+  // FIXME: This is redundant with wrapped eventToAd, we will need to do stuff
+  // here to make it compatible with event-based loading later.
   ad.isNFT = true;
   state.nftAds[ad.idx] = ad;
 
@@ -347,6 +350,8 @@ function eventToAd(state, adEvent) {
   // TODO will this break if we load stuff from events and not KetherView?
   if (adEvent.wrapped !== undefined) {
     ad.wrapped = adEvent.wrapped;
+  } else {
+    ad.wrapped = adEvent.owner === state.networkConfig.ketherNFTAddr;
   }
   let existingAd = state.ads[ad.idx];
   if (existingAd !== undefined && existingAd.width !== undefined) {

--- a/test/kethernft.js
+++ b/test/kethernft.js
@@ -401,29 +401,6 @@ describe('KetherNFT', function() {
     ).to.be.revertedWith("KetherNFT: invalid _owner");
   });
 
-  xit("it should return all of the ads as a helper", async function() {
-    const {owner, account1} = accounts;
-
-    // Buy an ad
-    const idx = await buyAd(account1);
-
-    // One more
-    const idx2 = await buyAd(account1, x=20, y=20);
-    expect(idx2).to.equal(1);
-
-    // Wrap one of them
-    const [salt, precomputeAddress] = await KNFT.connect(account1).precompute(idx, await account1.getAddress());
-
-    // Set owner to precommitted wrap address
-    await KH.connect(account1).setAdOwner(idx, precomputeAddress);
-
-    // Wrap ad
-    await KNFT.connect(account1).wrap(idx, await account1.getAddress());
-
-    const ads = await KNFT.connect(account1).allAds();
-    expect(ads).to.to.have.lengthOf(2);
-  });
-
   it("should let us upgrade the renderer", async function() {
     const {owner, account1} = accounts;
 

--- a/test/ketherview.js
+++ b/test/ketherview.js
@@ -1,0 +1,71 @@
+const { expect } = require('chai');
+
+const weiPixelPrice = ethers.utils.parseUnits("0.001", "ether");
+const pixelsPerCell = ethers.BigNumber.from(100);
+const oneHundredCellPrice = pixelsPerCell.mul(weiPixelPrice).mul(100);
+
+describe('KetherView', function() {
+  let KetherHomepage, KetherNFT, KetherView;
+  let accounts, KH, KNFT;
+
+  beforeEach(async () => {
+    // NOTE: We're using V2 here because it's ported to newer solidity so we can debug more easily. It should also work with V1.
+    KetherHomepage = await ethers.getContractFactory("KetherHomepageV2");
+    KetherNFT = await ethers.getContractFactory("KetherNFT");
+    KetherNFTRender = await ethers.getContractFactory("KetherNFTRender");
+    KetherView = await ethers.getContractFactory("KetherView");
+
+
+    const [owner, withdrawWallet, metadataSigner, account1, account2, account3] = await ethers.getSigners();
+    accounts = {owner, withdrawWallet, metadataSigner, account1, account2, account3};
+
+    KH = await KetherHomepage.deploy(await owner.getAddress(), await withdrawWallet.getAddress());
+    KNFTrender = await KetherNFTRender.deploy();
+    KNFT = await KetherNFT.deploy(KH.address, KNFTrender.address);
+    KV = await KetherView.deploy();
+
+  });
+
+  const buyAd = async function(account, x=0, y=0, width=10, height=10, link="link", image="image", title="title", NSFW=false, value=oneHundredCellPrice) {
+    const txn = await KH.connect(account).buy(x, y, width, height, { value: value });
+    const receipt = await txn.wait();
+    const event = receipt.events.pop();
+    const [idx] = event.args;
+    await KH.connect(account).publish(idx, link, image, title, false);
+    return idx;
+  }
+
+  it("it should return all of the ads as a helper", async function() {
+    const {
+      owner,
+      account1
+    } = accounts;
+
+    // Buy an ad
+    const idx = await buyAd(account1);
+
+    // One more
+    const idx2 = await buyAd(account1, x = 20, y = 20);
+    expect(idx2).to.equal(1);
+
+    // Wrap the second ad
+    const [salt, precomputeAddress] = await KNFT.connect(account1).precompute(idx2, await account1.getAddress());
+
+    // Set owner to precommitted wrap address
+    await KH.connect(account1).setAdOwner(idx2, precomputeAddress);
+
+    // Wrap ad
+    await KNFT.connect(account1).wrap(idx2, await account1.getAddress());
+
+    const ads = await KV.connect(account1).allAds(KH.address, KNFT.address);
+    expect(ads).to.to.have.lengthOf(2);
+
+    // first ad has us as owner and is not wrapped
+    expect(ads[0].owner).to.equal(account1.address)
+    expect(ads[0].wrapped).to.equal(false)
+
+    // second ad has us as owner and is wrapped
+    expect(ads[1].owner).to.equal(account1.address)
+    expect(ads[1].wrapped).to.equal(true)
+ });
+});

--- a/test/ketherview.js
+++ b/test/ketherview.js
@@ -56,16 +56,32 @@ describe('KetherView', function() {
 
     // Wrap ad
     await KNFT.connect(account1).wrap(idx2, await account1.getAddress());
+    {
+      // Get just the first ad
+      const ads = await KV.connect(account1).allAds(KH.address, KNFT.address, 0, 1);
+      expect(ads).to.to.have.lengthOf(1);
 
-    const ads = await KV.connect(account1).allAds(KH.address, KNFT.address);
-    expect(ads).to.to.have.lengthOf(2);
+      // ad has us as owner and is not wrapped
+      expect(ads[0].owner).to.equal(account1.address);
+      expect(ads[0].wrapped).to.equal(false);
+      expect(ads[0].idx).to.equal(0);
+    }
 
-    // first ad has us as owner and is not wrapped
-    expect(ads[0].owner).to.equal(account1.address)
-    expect(ads[0].wrapped).to.equal(false)
+    {
+      // Get just the second ad
+      const ads = await KV.connect(account1).allAds(KH.address, KNFT.address, 1, 1);
+      expect(ads).to.to.have.lengthOf(1);
 
-    // second ad has us as owner and is wrapped
-    expect(ads[1].owner).to.equal(account1.address)
-    expect(ads[1].wrapped).to.equal(true)
+      // second ad has us as owner and is wrapped
+      expect(ads[0].owner).to.equal(account1.address);
+      expect(ads[0].wrapped).to.equal(true);
+      expect(ads[0].idx).to.equal(1);
+    }
+
+    {
+      // Get more than all the ads
+      const ads = await KV.connect(account1).allAds(KH.address, KNFT.address, 0, 10000);
+      expect(ads).to.to.have.lengthOf(2);
+    }
  });
 });


### PR DESCRIPTION
This adds the KetherView library, proxies publish correctly to NFTed ads, ads and Unwrap, and a sketch of Wrap.

I also added a little counter of how many total wrapped we have in order to 🚀 the effort to NFT-ize these.

I've tested publishing and unwrapping on Rinkeby and it works.

# TODO
- [x] Deploy KetherView to mainnet
- [x] Wrap doesn't work because it tries both transactions at once, we need the setAdOwner to complete before we call wrap
- [x] Improve UX: is the Wrap/Unwrap button in the right place?
- [x] Improve UX: Better copy / icon for what's not "1 ads owned by you. (0 are wrapped as NFTs)"
- [x] We need to pick up SetAdOwner events to deal with wrapping/unwrapping (or get events from the NFT?)
- [x] Pick how big of a chunk size to use
- ~~If someone just did setAdOwner to the precomputed addr we need a way to  just call Wrap.~~ Opened #84

Closes #45