### PR TITLE
Get rid of all the `eth_chainid` calls

### DIFF
--- a/components/App.vue
+++ b/components/App.vue
@@ -150,7 +150,7 @@ export default {
     },
     async setReadOnlyNetwork(network) {
       const web3Fallback = deployConfig[network].web3Fallback || "http://localhost:8545/";
-      this.provider = new ethers.providers.JsonRpcProvider(web3Fallback);
+      this.provider = new ethers.providers.StaticJsonRpcProvider(web3Fallback);
       this.activeNetwork = (await this.provider.getNetwork()).name;
       this.networkConfig = deployConfig[this.activeNetwork];
       const contract = new ethers.Contract(this.networkConfig.contractAddr, contractJSON.abi, this.provider);

--- a/store/index.js
+++ b/store/index.js
@@ -143,7 +143,7 @@ export const actions = {
     if (route.name !== 'index') return; // We only want to preload ads for the index route
 
     const web3Fallback = deployConfig[defaultNetwork].web3Fallback || "http://localhost:8545/";
-    const provider = new ethers.providers.JsonRpcProvider(web3Fallback);
+    const provider = new ethers.providers.StaticJsonRpcProvider(web3Fallback);
     const activeNetwork = (await provider.getNetwork()).name;
     const networkConfig = deployConfig[activeNetwork];
     const contract = new ethers.Contract(networkConfig.contractAddr, contractJSON.abi, provider);


### PR DESCRIPTION
See https://github.com/ethers-io/ethers.js/issues/901#issuecomment-695101750 for context

This saves an extra call to infura on every interaction with the blockchain. I think it's safe to use the StaticJsonRpcProvider with Metamask because we do a hard-reload on network change, but I'd appreciate it if you read the linked issue and confirmed my understanding @shazow . The alternative would be to use the JsonRpcProvider if we detect a wallet?