### PR TITLE
Fix double load

### DIFF
--- a/components/App.vue
+++ b/components/App.vue
@@ -176,7 +176,6 @@ export default {
       this.contract.on('error', function(err) {
         console.error("Contract subscription error:", err);
       });
-      // FIXME this will trigger a second reload (using ketherview) when the user connects their wallet
       this.$store.dispatch('loadAds', {contract, ketherNFT, ketherView});
     },
     listenContractEvents(contract) {

--- a/store/index.js
+++ b/store/index.js
@@ -286,9 +286,7 @@ export const actions = {
   async detectHalfWrapped({ state, commit }, { ketherContract, nftContract, numBlocks }) {
     // FIXME: Probably should move this into Wrap or a ResumeWrap component, no need to pollute global state
     const account = state.activeAccount;
-    console.log("statrt")
     if (!account) {
-      console.error("Can't detect half-wrapped ads without an active account. Connect a wallet.");
       return;
     }
     if (numBlocks === undefined) {

--- a/store/index.js
+++ b/store/index.js
@@ -229,6 +229,8 @@ export const actions = {
     const loadFromKetherView = !!state.networkConfig.ketherViewAddr && state.loadedNetwork != activeNetwork; // Only use View contract if deployed & we haven't loaded already
     const loadFromEvents = true; // Okay to do it always? or should we do: state.loadedBlockNumber > 0
 
+    commit('setLoadedNetwork', {network: activeNetwork, blockNumber: blockNumber, timestamp: blockTimestamp});
+
     if (loadFromKetherView) {
       console.log("Loading from KetherView");
       const loadKetherView = async (offset, limit, retries = 0) => {
@@ -271,8 +273,6 @@ export const actions = {
         commit('addAd', toAd(i, await ad));
       }
     }
-
-    commit('setLoadedNetwork', {network: activeNetwork, blockNumber: blockNumber, timestamp: blockTimestamp});
   },
 
   async addAccount({ commit, state }, account) {


### PR DESCRIPTION
This fixed a race condition where we load things twice. Now we set the network & block number being loaded from before we finish doing all the calls so we don't double the number of calls / load every image twice speeding up the first load
