### PR TITLE
components/AdGrid.vue: image-rendering: pixelated for ad images

### DIFF
--- a/components/AdGrid.vue
+++ b/components/AdGrid.vue
@@ -17,6 +17,7 @@
     font-size: 11px;
     color: rgba(0, 0, 0, 0.7);
     white-space: nowrap;
+    image-rendering: pixelated;
   }
 
   .blank {


### PR DESCRIPTION
Fixes #91

This is the CSS3 standard way of doing this, don't need all the others for modern browsers.

Before:
![image](https://user-images.githubusercontent.com/6292/133489513-8a47baee-24e0-487b-adcf-1db027dc82cc.png)

After:
![image](https://user-images.githubusercontent.com/6292/133489486-63f01ebe-8816-4f91-a7a5-de6e91e6a299.png)
