### PR TITLE
store/index.js: normalize adEvent.owner before comparing wrapped state

### DIFF
--- a/store/index.js
+++ b/store/index.js
@@ -419,7 +419,7 @@ function eventToAd(state, adEvent) {
   if (adEvent.wrapped !== undefined) {
     ad.wrapped = adEvent.wrapped;
   } else {
-    ad.wrapped = adEvent.owner === state.networkConfig.ketherNFTAddr;
+    ad.wrapped = normalizeAddr(adEvent.owner) === state.networkConfig.ketherNFTAddr;
   }
   let existingAd = state.ads[ad.idx];
   if (existingAd !== undefined && existingAd.width !== undefined) {


### PR DESCRIPTION
Re: #94

Probably not the fix but still necessary.