### PR TITLE
Refactor eventToAd; Add listeners for transfer events

### DIFF
--- a/components/App.vue
+++ b/components/App.vue
@@ -225,7 +225,6 @@ export default {
 
         this.$store.commit('updateAd', {idx: idx.toNumber(), toUpdate: {owner: to, wrapped: true}});
         console.log("[KetherNFT] Transfer event processed.");
-        debugger;
       }.bind(this));
     },
   },

--- a/components/Wrap.vue
+++ b/components/Wrap.vue
@@ -138,7 +138,7 @@ export default {
           await tx.wait();
         }
 
-        this.$store.commit('importAds', [Object.assign(this.ad, {owner: signerAddr, wrapped: true})]);
+        this.$store.commit('updateAd', {idx: this.ad.idx, toUpdate: {owner: signerAddr, wrapped: true}});
         this.$store.commit('removeHalfWrapped', this.ad.idx);
 
         this.error = null; // Reset error if completed successfully.
@@ -159,7 +159,7 @@ export default {
           this.wrapInProgress = "Unwrapping transaction submitted, waiting...";
           await tx.wait();
         }
-        this.$store.commit('importAds', [Object.assign(this.ad, {wrapped: false})]);
+        this.$store.commit('updateAd', {idx: this.ad.idx, toUpdate: {wrapped: false}});
 
         this.error = null; // Reset error if completed successfully.
       } catch(err) {

--- a/components/Wrap.vue
+++ b/components/Wrap.vue
@@ -138,7 +138,7 @@ export default {
           await tx.wait();
         }
 
-        this.$store.commit('updateAd', {idx: this.ad.idx, toUpdate: {owner: signerAddr, wrapped: true}});
+        this.$store.commit('updateAds', [{idx: this.ad.idx, update: {owner: signerAddr, wrapped: true}}]);
         this.$store.commit('removeHalfWrapped', this.ad.idx);
 
         this.error = null; // Reset error if completed successfully.
@@ -159,7 +159,7 @@ export default {
           this.wrapInProgress = "Unwrapping transaction submitted, waiting...";
           await tx.wait();
         }
-        this.$store.commit('updateAd', {idx: this.ad.idx, toUpdate: {wrapped: false}});
+        this.$store.commit('updateAds', [{idx: this.ad.idx, update: {wrapped: false}}]);
 
         this.error = null; // Reset error if completed successfully.
       } catch(err) {

--- a/store/index.js
+++ b/store/index.js
@@ -9,7 +9,6 @@ export const state = () => {
     ads: [],
     adsPixels: 0,
     ownedAds: {},
-    nftAds: {},
     halfWrapped: {},
     pixelsOwned: 0,
     grid: null, // lazy load
@@ -85,7 +84,6 @@ export const mutations = {
     state.ads = [];
     state.adsPixels = 0;
     state.ownedAds = {};
-    state.nftAds = {};
     state.pixelsOwned = 0;
     state.loadedBlockNumber = 0;
     state.networkConfig = networkConfig;

--- a/store/index.js
+++ b/store/index.js
@@ -34,11 +34,13 @@ function normalizeAd(rawAd) {
   let normalized = {idx: undefined, owner: undefined, x: undefined, y: undefined, width: undefined, height: undefined, link: "", image: "", title: "", NSFW: false, forceNSFW: false, wrapped: false};
   for (const key in normalized) {
     const value = rawAd[key];
-    if (value && value._isBigNumber) {
-      normalized[key] = value.toNumber();
-    } else {
-      normalized[key] = value;
-    }
+    if (value !== undefined) {
+      if (value._isBigNumber) {
+        normalized[key] = value.toNumber();
+      } else {
+        normalized[key] = value;
+      }
+   }
   }
   normalized.owner = normalizeAddr(normalized.owner);
 

--- a/store/index.js
+++ b/store/index.js
@@ -44,6 +44,11 @@ function normalizeAd(rawAd) {
   }
   normalized.owner = normalizeAddr(normalized.owner);
 
+  // Flip NSFW always if forceNSFW is set
+  if (normalized.forceNSFW) {
+    normalized.NSFW = true;
+  }
+
   return normalized;
 }
 


### PR DESCRIPTION
Closes #90 

eventToAd was getting too complex. Refactored into a normalizeAd, addAd, and updateAd. This also lets us be reactive for transfer events pretty easily.
