### PR TITLE
Fix all the address comparisons in Wrap and Publish

### DIFF
--- a/components/Publish.vue
+++ b/components/Publish.vue
@@ -150,7 +150,7 @@ export default {
       this.inProgress = 'Waiting for wallet to confirm.';
 
       // Load latest wrapped state from blockchain (avoid stale state)
-      const isWrapped = (await this.contract.ads(this.ad.idx)).owner === this.ketherNFT.address;
+      const isWrapped = this.$address.equal((await this.contract.ads(this.ad.idx)).owner, this.ketherNFT.address);
 
       try {
         let tx;

--- a/components/Wrap.vue
+++ b/components/Wrap.vue
@@ -120,14 +120,14 @@ export default {
         }
 
         const expectedPredictedAddress = this.$store.getters.precomputeEscrow({idx: this.ad.idx, KH: this.contract, KNFT: this.ketherNFT});
-        if (predictedAddress != expectedPredictedAddress) {
+        if (!this.$address.equal(predictedAddress, expectedPredictedAddress)) {
           throw "predictedAddress does not match expected value, something went wrong: " + predictedAddress + " != " + expectedPredictedAddress;
         }
 
         this.wrapInProgress = "Fetching latest state...";
 
         // Change ad owner if not already changed (check for stale state)
-        if ((await this.contract.ads(this.ad.idx)).owner === predictedAddress) {
+        if (this.$address.equal((await this.contract.ads(this.ad.idx)).owner, predictedAddress)) {
           // setAdOwner already done, skip
           this.$store.commit('addHalfWrapped', {idx: this.ad.idx, account: signerAddr});
 
@@ -140,7 +140,7 @@ export default {
         }
 
         // Wrap if not already wrapped (check for stale state again)
-        if ((await this.contract.ads(this.ad.idx)).owner !== this.ketherNFT.address) {
+        if (!this.$address.equal((await this.contract.ads(this.ad.idx)).owner, this.ketherNFT.address)) {
           this.wrapInProgress = "Confirm 2nd wrap transaction, check your wallet queue.";
           const tx = await this.ketherNFT.connect(signer).wrap(this.ad.idx, signerAddr);
           this.wrapInProgress = "Second transaction submitted, waiting...";
@@ -163,7 +163,7 @@ export default {
 
       try {
         // Unwrap if ketherNFT is the owner (check for stale state)
-        if ((await this.contract.ads(this.ad.idx)).owner === this.ketherNFT.address) {
+        if (this.$address.equal((await this.contract.ads(this.ad.idx)).owner, this.ketherNFT.address)) {
           const tx = await this.ketherNFT.connect(signer).unwrap(this.ad.idx, signerAddr);
           this.wrapInProgress = "Unwrapping transaction submitted, waiting...";
           await tx.wait();

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -55,9 +55,10 @@ export default {
   ],
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
-  plugins: [{
-    src: '~/plugins/spinner.js', mode: 'client'
-  }],
+  plugins: [
+    {src: '~/plugins/spinner.js', mode: 'client'},
+    {src: '~/plugins/address.js'}
+  ],
 
   // Auto import components: https://go.nuxtjs.dev/config-components
   components: true,

--- a/plugins/address.js
+++ b/plugins/address.js
@@ -1,0 +1,14 @@
+const address = {
+  normalize(addr) {
+    if (!addr) return addr;
+    return addr.toLowerCase();
+  },
+
+  equal(addr1, addr2) {
+    return this.normalize(addr1) === this.normalize(addr2);
+  }
+};
+
+export default (_context, inject) => {
+  inject('address', address);
+}


### PR DESCRIPTION
It's our old friend, addresses being case sensitive. 

The bug is that in the networkConfig we have a checksummed address in rinkeby and lowercase in homestead.

I added a global `this.$address.normalize` and `this.$address.equal` and fixed all the comparisons in Wrap and Publish.

