### PR TITLE
components/Homepage.vue: Add missing button for single old half-wrapped ads

### DIFF
--- a/components/Homepage.vue
+++ b/components/Homepage.vue
@@ -49,6 +49,7 @@ section {
     </div>
     <p v-else-if="$store.state.activeAccount">
       No purchased ads detected for active accounts. Reload after buying an ad.
+      <button type="button" v-on:click="tab = 'missing'" :disabled="tab == 'missing'">Find Missing Ad</button>
     </p>
 
     <section>


### PR DESCRIPTION
This adds a "Find Missing" button for when you have no valid ads available, but you have an old half-wrapped ad that is outside of our default search window.

Also the resulting checklist is probably useful anyway:

![image](https://user-images.githubusercontent.com/6292/149668286-f53de3f9-74cf-44bf-9278-735eda37c68f.png)
